### PR TITLE
Bump text-to-cypher to 0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -106,7 +106,6 @@ if [ "$PUSH" = "true" ]; then
     echo -e "${GREEN}Building and pushing multi-platform Docker image...${NC}"
     docker buildx build \
         --platform ${PLATFORMS} \
-        --pull \
         --build-arg VERSION=${VERSION} \
         -t ${FULL_IMAGE_NAME}:${VERSION} \
         -t ${FULL_IMAGE_NAME}:latest \
@@ -116,7 +115,6 @@ else
     echo -e "${GREEN}Building multi-platform Docker image (local only)...${NC}"
     docker buildx build \
         --platform ${PLATFORMS} \
-        --pull \
         --build-arg VERSION=${VERSION} \
         -t ${FULL_IMAGE_NAME}:${VERSION} \
         -t ${FULL_IMAGE_NAME}:latest \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -106,6 +106,7 @@ if [ "$PUSH" = "true" ]; then
     echo -e "${GREEN}Building and pushing multi-platform Docker image...${NC}"
     docker buildx build \
         --platform ${PLATFORMS} \
+        --pull \
         --build-arg VERSION=${VERSION} \
         -t ${FULL_IMAGE_NAME}:${VERSION} \
         -t ${FULL_IMAGE_NAME}:latest \
@@ -115,6 +116,7 @@ else
     echo -e "${GREEN}Building multi-platform Docker image (local only)...${NC}"
     docker buildx build \
         --platform ${PLATFORMS} \
+        --pull \
         --build-arg VERSION=${VERSION} \
         -t ${FULL_IMAGE_NAME}:${VERSION} \
         -t ${FULL_IMAGE_NAME}:latest \


### PR DESCRIPTION
## Summary
- Bump text-to-cypher crate version to 0.1.11
- Update Cargo.lock package version

## Validation
- cargo check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump for maintenance release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->