### PR TITLE
Avoid logging full CSV files during load

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -116,6 +116,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
       - name: Log in to Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
@@ -336,6 +339,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Log in to Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4

--- a/src/main.rs
+++ b/src/main.rs
@@ -1733,30 +1733,13 @@ fn execute_query_with_existing_csv_blocking(
 
         tracing::info!("CSV file found at: {:?}", file_path);
 
-        // Read and log each line of the CSV file
-        match std::fs::read_to_string(&file_path) {
-            Ok(csv_content) => {
-                let lines: Vec<&str> = csv_content.lines().collect();
-                tracing::info!("CSV file '{}' contains {} lines", csv_filename, lines.len());
-
-                for (line_number, line) in lines.iter().enumerate() {
-                    let line_num = line_number + 1; // 1-based line numbering
-                    tracing::info!("CSV line {}: {}", line_num, line);
-                }
-
-                if lines.is_empty() {
-                    tracing::warn!("CSV file '{}' is empty", csv_filename);
-                } else {
-                    tracing::info!(
-                        "Finished logging all {} lines from CSV file '{}'",
-                        lines.len(),
-                        csv_filename
-                    );
-                }
+        match std::fs::metadata(&file_path) {
+            Ok(metadata) => {
+                tracing::info!("CSV file '{}' size: {} bytes", csv_filename, metadata.len());
             }
             Err(e) => {
-                tracing::warn!("Failed to read CSV file '{}' for line logging: {}", csv_filename, e);
-                // Continue with execution even if reading for logging fails
+                tracing::warn!("Failed to read CSV file '{}' metadata: {}", csv_filename, e);
+                // Continue with execution even if reading metadata fails.
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid reading and logging every CSV row before executing LOAD CSV
- log CSV file size metadata instead to keep large multi-part Snowflake loads responsive
- set up QEMU in Docker release build and verify jobs so ARM64 image verification can run on GitHub-hosted runners

## Testing
- cargo check --quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker release workflow to support multi-architecture container image builds

* **Refactor**
  * Optimized file processing logging by switching to metadata-based reporting for improved performance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/text-to-cypher/pull/111)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->