### PR TITLE
chore: bump release for FalkorDB 4.18.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN echo "Downloading text-to-cypher ${VERSION} for ${TARGETPLATFORM} (${TARGETO
 RUN test -x /tmp/text-to-cypher && echo "Binary verification completed"
 
 # Runtime stage - Use FalkorDB as base image
-FROM falkordb/falkordb:latest
+FROM falkordb/falkordb:v4.18.6
 
 # Repair the minimal base image package state before installing supervisord.
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN echo "Downloading text-to-cypher ${VERSION} for ${TARGETPLATFORM} (${TARGETO
 RUN test -x /tmp/text-to-cypher && echo "Binary verification completed"
 
 # Runtime stage - Use FalkorDB as base image
-FROM falkordb/falkordb:v4.18.6
+FROM falkordb/falkordb:latest
 
 # Repair the minimal base image package state before installing supervisord.
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- Bump text-to-cypher crate version to 0.1.14
- Update Cargo.lock for the new package version
- Pin the runtime Docker base image to falkordb/falkordb:v4.18.6

## Validation
- cargo check --quiet

Note: the FalkorDB v4.18.6 Docker tag is expected to be published before this release is built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.14
  * Docker base image pinned to FalkorDB v4.18.6

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/text-to-cypher/pull/115)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->