### PR TITLE
chore: bump release for FalkorDB 4.18.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"


### PR DESCRIPTION
## Summary
- bump text-to-cypher package version to v0.1.15
- keep Docker base on falkordb/falkordb:latest, which now points to FalkorDB v4.18.6 with the Browser startup fix

## Testing
- cargo check --quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.15

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/text-to-cypher/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->