### PR TITLE
Add curated static model catalog merged with dynamic listing

### DIFF
--- a/examples/list_client_models.rs
+++ b/examples/list_client_models.rs
@@ -1,0 +1,73 @@
+//! Example demonstrating `TextToCypherClient::list_models` and `list_all_models`
+//!
+//! This example shows how to discover which AI models are available, using the
+//! high-level `TextToCypherClient` API:
+//! - `list_models(adapter_kind)` lists the models for a single provider
+//! - `list_all_models()` lists models across all supported providers
+//!
+//! No `FalkorDB` connection is required for listing models, but the client is
+//! configured with an API key which is forwarded to the providers.
+//!
+//! To run this example:
+//! 1. Set an API key for the provider you want to query, e.g.
+//!    `export OPENAI_API_KEY=your-key-here`
+//! 2. Run: `cargo run --example list_client_models --no-default-features`
+
+use text_to_cypher::{AdapterKind, TextToCypherClient};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing for better debugging (only if available).
+    #[cfg(feature = "server")]
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    // Pick up an API key from the environment. Listing models for some providers
+    // (e.g. Ollama) works without a key, while hosted providers require one.
+    let api_key = std::env::var("OPENAI_API_KEY")
+        .or_else(|_| std::env::var("ANTHROPIC_API_KEY"))
+        .or_else(|_| std::env::var("GEMINI_API_KEY"))
+        .unwrap_or_default();
+
+    // The model and connection string are not used for listing models, but the
+    // client requires them. The configured API key is what gets forwarded.
+    let client = TextToCypherClient::new("gpt-4o-mini", &api_key, "falkor://127.0.0.1:6379");
+
+    // Method 1: list models for a single provider.
+    println!("=== Method 1: list_models for a single provider ===\n");
+    let adapter = AdapterKind::OpenAI;
+    match client.list_models(adapter).await {
+        Ok(models) => {
+            println!("{adapter}: found {} models", models.len());
+            for model in &models {
+                println!("  • {model}");
+            }
+        }
+        Err(e) => eprintln!("  ✗ Error fetching {adapter} models: {e}"),
+    }
+
+    // Method 2: list models across all supported providers at once.
+    //
+    // Note: each provider's live results are merged with a curated static catalog, so
+    // providers with a catalog still return their well-known models even without a
+    // matching API key. Providers without a catalog (e.g. Ollama) only appear when
+    // reachable.
+    println!("\n=== Method 2: list_all_models across all providers ===\n");
+    match client.list_all_models().await {
+        Ok(all_models) => {
+            let total: usize = all_models.values().map(Vec::len).sum();
+            println!("Total models across all providers: {total}\n");
+            for (kind, models) in all_models {
+                println!("{kind}: {} models", models.len());
+            }
+        }
+        Err(e) => eprintln!("Error fetching all models: {e}"),
+    }
+
+    println!("\n=== Example completed successfully! ===");
+    Ok(())
+}

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,34 @@ export OPENAI_API_KEY=your-key-here
 cargo run --example library_usage --no-default-features
 ```
 
+**Listing available models:**
+
+To discover which AI models each provider supports, use `TextToCypherClient::list_models`
+(single provider) and `list_all_models` (all providers). See the
+[list models example](examples/list_client_models.rs).
+
+```bash
+# Optionally set an API key to fetch the provider's live model list
+export OPENAI_API_KEY=your-key-here
+
+# Run the example (library mode - no server dependencies)
+cargo run --example list_client_models --no-default-features
+```
+
+> Results combine the provider's **dynamic** list (fetched live from the provider, which
+> usually needs an API key) with a **curated static catalog** maintained in
+> [`src/models_catalog.rs`](src/models_catalog.rs). Because of this fallback, providers
+> with a curated list still return their well-known models even when no API key is
+> configured. The curated catalog is intentionally small and high-confidence — update it
+> when adding support for newer models.
+
+There is also a lower-level [`list_models` example](examples/list_models.rs) that calls
+the `core::list_adapter_models` / `core::list_all_models` functions directly:
+
+```bash
+cargo run --example list_models --no-default-features
+```
+
 ### Using from TypeScript/JavaScript
 
 See [TypeScript Usage Guide](docs/TYPESCRIPT_USAGE.md) for detailed instructions on using text-to-cypher from TypeScript/JavaScript applications via REST API, Node.js native bindings, or WebAssembly.

--- a/src/core.rs
+++ b/src/core.rs
@@ -403,7 +403,16 @@ fn execute_query_blocking(
     })
 }
 
-/// Lists all available model names for a specific AI provider
+/// Lists available model names for a specific AI provider.
+///
+/// The result combines two sources:
+/// 1. The *dynamic* list returned by `genai` (a live, usually authenticated request to
+///    the provider — see [`crate::models_catalog`]).
+/// 2. A *curated static* fallback list of well-known models for the provider.
+///
+/// Dynamic models keep their provider-native ordering and appear first; curated models
+/// not already present are appended. This means the function returns useful results even
+/// when no API key is configured (the dynamic call fails but the curated list is used).
 ///
 /// # Arguments
 ///
@@ -412,11 +421,13 @@ fn execute_query_blocking(
 ///
 /// # Returns
 ///
-/// A vector of model names supported by the adapter
+/// A vector of model names for the adapter (dynamic results merged with the curated catalog).
 ///
 /// # Errors
 ///
-/// Returns an error if the model listing request fails
+/// Returns an error only when the dynamic listing fails *and* no curated static models
+/// exist for the provider (e.g. `Ollama`). When a curated list is available, a failed
+/// dynamic call is logged as a warning and the curated list is returned instead.
 ///
 /// # Examples
 ///
@@ -436,15 +447,25 @@ pub async fn list_adapter_models(
     adapter_kind: AdapterKind,
     client: &GenAiClient,
 ) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
-    let models = client
-        .all_model_names(adapter_kind, ())
-        .await
-        .map_err(|e| format!("Failed to fetch models for {adapter_kind}: {e}"))?;
+    let statics = crate::models_catalog::static_models(adapter_kind);
 
-    Ok(models)
+    match client.all_model_names(adapter_kind, ()).await {
+        Ok(dynamic) => Ok(crate::models_catalog::merge_models(dynamic, statics)),
+        Err(e) => crate::models_catalog::static_fallback(statics).map_or_else(
+            || Err(format!("Failed to fetch models for {adapter_kind}: {e}").into()),
+            |models| {
+                tracing::warn!("Dynamic model listing for {adapter_kind} failed ({e}); using curated static catalog");
+                Ok(models)
+            },
+        ),
+    }
 }
 
 /// Lists all available models across all supported AI providers
+///
+/// Each provider's dynamic results are merged with a curated static catalog (see
+/// [`list_adapter_models`]), so providers with a curated list still return models even
+/// when no matching API key is configured.
 ///
 /// # Arguments
 ///
@@ -457,8 +478,9 @@ pub async fn list_adapter_models(
 /// # Errors
 ///
 /// This function returns `Ok` with partial results even when individual adapters fail.
-/// Individual adapter failures are logged as warnings and skipped, allowing the function
-/// to continue and return results from successful adapters
+/// Individual adapter failures (only possible for providers without a curated static
+/// list, e.g. `Ollama`) are logged as warnings and skipped, allowing the function to
+/// continue and return results from the other providers.
 ///
 /// # Examples
 ///
@@ -487,13 +509,14 @@ pub async fn list_all_models(
         AdapterKind::Anthropic,
         AdapterKind::Groq,
         AdapterKind::Cohere,
-        // Add DeepSeek, xAI/Grok if available in your version
+        AdapterKind::DeepSeek,
+        AdapterKind::Xai,
     ];
 
     let mut results = HashMap::new();
 
     for &adapter in ADAPTERS {
-        match client.all_model_names(adapter, ()).await {
+        match list_adapter_models(adapter, client).await {
             Ok(models) => {
                 results.insert(adapter, models);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ pub mod chat;
 pub mod core;
 pub mod error;
 pub mod formatter;
+pub mod models_catalog;
 pub mod processor;
 pub mod schema;
 pub mod skills;
@@ -485,10 +486,10 @@ impl TextToCypherClient {
     ///
     /// # Note
     ///
-    /// This method uses the API key configured in the client. Different providers
-    /// require different API keys, so only the provider matching the configured key
-    /// will successfully return results. Other providers will be logged as warnings
-    /// and skipped.
+    /// Each provider's live results are merged with a curated static catalog, so
+    /// providers with a curated list still return models even when the configured API
+    /// key does not match them. Providers without a curated list (e.g. Ollama) are only
+    /// returned when reachable.
     ///
     /// # Example
     ///

--- a/src/models_catalog.rs
+++ b/src/models_catalog.rs
@@ -145,13 +145,17 @@ mod tests {
             AdapterKind::Gemini,
             AdapterKind::Groq,
             AdapterKind::Cohere,
+            AdapterKind::DeepSeek,
+            AdapterKind::Xai,
         ] {
             assert!(!static_models(kind).is_empty(), "{kind} should have curated models");
         }
     }
 
     #[test]
-    fn static_models_unknown_provider_empty() {
+    fn static_models_uncatalogued_provider_empty() {
+        // Ollama is a known provider but intentionally has no curated catalog
+        // (its models are listed from a local daemon).
         assert!(static_models(AdapterKind::Ollama).is_empty());
     }
 

--- a/src/models_catalog.rs
+++ b/src/models_catalog.rs
@@ -1,0 +1,195 @@
+//! Curated fallback catalog of model names per AI provider.
+//!
+//! `genai`'s `Client::all_model_names` is *dynamic*: for hosted providers such as
+//! `OpenAI`, Anthropic, Gemini and Groq it performs a live, authenticated HTTP request
+//! to the provider's `/models` endpoint. Without a valid API key those calls fail, so
+//! no models can be listed. A few adapters (e.g. Cohere) return a hardcoded list and
+//! work without a key, and Ollama lists models from a local daemon.
+//!
+//! To give callers a useful list even when no key is configured, this module maintains
+//! a small, curated set of well-known model names per provider. These lists are merged
+//! with the dynamic results (see [`crate::core::list_adapter_models`]).
+//!
+//! This is a *curated convenience catalog*, not an authoritative list of everything the
+//! provider or `genai` supports. `genai` routes a model to an adapter by name prefix
+//! (e.g. `gpt*` → `OpenAI`, `claude*` → Anthropic), so additional models not listed here
+//! still work as long as they use the expected prefix.
+//!
+//! Last reviewed against `genai` 0.6.3. Keep these lists short and high-confidence;
+//! update them when adding support for newer models.
+
+use genai::adapter::AdapterKind;
+
+/// Curated `OpenAI` model names.
+const OPENAI_MODELS: &[&str] = &[
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5-codex",
+    "o1",
+    "o1-mini",
+    "o3",
+    "o3-mini",
+    "o4-mini",
+];
+
+/// Curated Anthropic model names.
+const ANTHROPIC_MODELS: &[&str] = &[
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-opus-4-5",
+    "claude-3-7-sonnet-latest",
+    "claude-3-5-sonnet-latest",
+    "claude-3-5-haiku-latest",
+    "claude-3-haiku-20240307",
+];
+
+/// Curated Google Gemini model names.
+const GEMINI_MODELS: &[&str] = &[
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+];
+
+/// Curated Groq model names.
+const GROQ_MODELS: &[&str] = &[
+    "llama-3.3-70b-versatile",
+    "llama-3.1-8b-instant",
+    "mixtral-8x7b-32768",
+    "gemma2-9b-it",
+];
+
+/// Curated `DeepSeek` model names.
+const DEEPSEEK_MODELS: &[&str] = &["deepseek-chat", "deepseek-reasoner"];
+
+/// Curated xAI (Grok) model names.
+const XAI_MODELS: &[&str] = &["grok-4", "grok-3", "grok-3-mini", "grok-2-vision"];
+
+/// Curated Cohere model names (mirrors `genai`'s static Cohere list).
+const COHERE_MODELS: &[&str] = &[
+    "command-r-plus",
+    "command-r",
+    "command",
+    "command-nightly",
+    "command-light",
+    "command-light-nightly",
+];
+
+/// Returns the curated, statically-known model names for a given provider.
+///
+/// Returns an empty slice for providers without a curated list (e.g. Ollama, which is
+/// listed from a local daemon, or any adapter not covered here).
+#[must_use]
+pub const fn static_models(adapter_kind: AdapterKind) -> &'static [&'static str] {
+    match adapter_kind {
+        AdapterKind::OpenAI => OPENAI_MODELS,
+        AdapterKind::Anthropic => ANTHROPIC_MODELS,
+        AdapterKind::Gemini => GEMINI_MODELS,
+        AdapterKind::Groq => GROQ_MODELS,
+        AdapterKind::DeepSeek => DEEPSEEK_MODELS,
+        AdapterKind::Xai => XAI_MODELS,
+        AdapterKind::Cohere => COHERE_MODELS,
+        _ => &[],
+    }
+}
+
+/// Returns a curated static model list to use when a dynamic listing fails.
+///
+/// Returns `Some` (the curated list as owned strings) when the provider has a curated
+/// catalog, or `None` when it does not — in which case the caller should propagate the
+/// original dynamic error.
+#[must_use]
+pub fn static_fallback(statics: &[&str]) -> Option<Vec<String>> {
+    if statics.is_empty() {
+        None
+    } else {
+        Some(merge_models(Vec::new(), statics))
+    }
+}
+
+/// Merges dynamically-fetched model names with the curated static list.
+///
+/// Dynamic models keep their original (provider-native) ordering and appear first.
+/// Any curated model not already present is appended afterwards. De-duplication is an
+/// exact, case-sensitive match, so distinct aliases (e.g. `*-latest` vs a dated
+/// snapshot) are preserved.
+#[must_use]
+pub fn merge_models(
+    dynamic: Vec<String>,
+    statics: &[&str],
+) -> Vec<String> {
+    let mut merged = dynamic;
+    for &model in statics {
+        if !merged.iter().any(|existing| existing == model) {
+            merged.push(model.to_string());
+        }
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_models_known_providers_non_empty() {
+        for kind in [
+            AdapterKind::OpenAI,
+            AdapterKind::Anthropic,
+            AdapterKind::Gemini,
+            AdapterKind::Groq,
+            AdapterKind::Cohere,
+        ] {
+            assert!(!static_models(kind).is_empty(), "{kind} should have curated models");
+        }
+    }
+
+    #[test]
+    fn static_models_unknown_provider_empty() {
+        assert!(static_models(AdapterKind::Ollama).is_empty());
+    }
+
+    #[test]
+    fn merge_preserves_dynamic_order_and_appends_missing_statics() {
+        let dynamic = vec!["gpt-4o".to_string(), "gpt-custom".to_string()];
+        let statics = &["gpt-4o", "gpt-5"];
+        let merged = merge_models(dynamic, statics);
+
+        assert_eq!(merged, vec!["gpt-4o", "gpt-custom", "gpt-5"]);
+    }
+
+    #[test]
+    fn merge_dedups_exact_matches_only() {
+        let dynamic = vec!["claude-3-5-sonnet-latest".to_string()];
+        let statics = &["claude-3-5-sonnet-latest", "claude-3-5-sonnet-20241022"];
+        let merged = merge_models(dynamic, statics);
+
+        // Exact duplicate dropped, the distinct dated alias kept.
+        assert_eq!(merged, vec!["claude-3-5-sonnet-latest", "claude-3-5-sonnet-20241022"]);
+    }
+
+    #[test]
+    fn merge_with_empty_dynamic_returns_statics() {
+        let merged = merge_models(Vec::new(), &["command-r", "command"]);
+        assert_eq!(merged, vec!["command-r", "command"]);
+    }
+
+    #[test]
+    fn static_fallback_some_when_catalog_present() {
+        assert_eq!(
+            static_fallback(&["a", "b"]),
+            Some(vec!["a".to_string(), "b".to_string()])
+        );
+    }
+
+    #[test]
+    fn static_fallback_none_when_catalog_empty() {
+        assert_eq!(static_fallback(&[]), None);
+    }
+}


### PR DESCRIPTION
## Summary

`genai`'s `all_model_names` is *dynamic*: for hosted providers (OpenAI, Anthropic, Gemini, Groq, …) it performs a live, authenticated request to the provider's `/models` endpoint. Without a valid API key those calls fail, so no models can be listed.

This PR maintains a curated **static catalog** of well-known models per provider (reviewed against `genai` 0.6.3) and **merges** it with the dynamic results, so callers get useful results even when no API key is configured.

## Changes

- **New `src/models_catalog.rs`**
  - `static_models(AdapterKind) -> &'static [&'static str]` — curated lists for OpenAI, Anthropic, Gemini, Groq, Cohere, DeepSeek, xAI (empty for uncatalogued providers).
  - `merge_models(dynamic, statics)` — keeps provider-native dynamic ordering first, appends curated entries not already present; exact case-sensitive de-dup (preserves distinct dated aliases like `*-latest` vs snapshots).
  - `static_fallback(statics)` — pure, testable helper for the keyless fallback decision.
- **`src/core.rs`**
  - `list_adapter_models` merges dynamic + static and gracefully falls back to the curated list when the dynamic call fails (e.g. no API key). Errors only when the dynamic call fails *and* no curated list exists (e.g. Ollama).
  - `list_all_models` delegates to `list_adapter_models` and now also lists DeepSeek and xAI.
- **`examples/list_client_models.rs`** (new) — demonstrates `TextToCypherClient::list_models` and `list_all_models`.
- **`readme.md`** — documents how to run the example and the merge/fallback behavior.
- Updated related doc comments in `src/lib.rs` / `src/core.rs`.

## Behavior

Before (no key): `OpenAI` returned a `401` and 0 models.
After (no key): every curated provider returns its well-known models:

```
OpenAI: 13, Anthropic: 7, Gemini: 5, Groq: 4, Cohere: 6, DeepSeek: 2, xAI: 4
```

The curated catalog is intentionally small and high-confidence; it should be updated when adding support for newer models.

## Testing

- `cargo fmt -- --check` ✓
- `cargo clippy -- -W clippy::pedantic -W clippy::nursery -D warnings` ✓
- `cargo test` ✓ (incl. new unit tests for `merge_models` / `static_fallback`)
- `cargo build --release` ✓
- Ran `cargo run --example list_client_models --no-default-features` keyless ✓

This change was reviewed via a rubber-duck pass (coverage of DeepSeek/xAI, pure fallback helper, and doc/example consistency were addressed as a result).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for listing available AI models from all configured providers.
  * Enhanced model retrieval by combining real-time provider models with curated fallback options.
  * Extended provider support to include additional AI services.

* **Documentation**
  * Updated README with a new section demonstrating how to discover and explore available AI models, including practical examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->