### PR TITLE
chore: bump version to 0.1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"


### PR DESCRIPTION
Bump version from 0.1.18 to 0.1.19 ahead of cutting the `v0.1.19` release.

Follows the token-usage example/docs change merged in #130.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.19

<!-- end of auto-generated comment: release notes by coderabbit.ai -->