### PR TITLE
chore: upgrade falkordb to 0.8.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,10 +1062,12 @@ dependencies = [
 
 [[package]]
 name = "falkordb"
-version = "0.3.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828bd750fcaf183b8126548bef16abb75ee93ba06a248213c07a9ad2cebed0ee"
+checksum = "b511c066745e2326bcd72f98cb41f0081d8fa03dff8a1506da7c1c3c1afbd460"
 dependencies = [
+ "backon",
+ "futures-core",
  "parking_lot",
  "redis",
  "regex",
@@ -2222,11 +2234,14 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6b5f4d8ef33944e833e2b1859ad478deab6e431d7337b30ee2efe21f7543"
 dependencies = [
+ "arc-swap",
  "arcstr",
  "async-lock",
+ "backon",
  "bytes",
  "cfg-if",
  "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_yaml_ng = "0.10"
 tracing = { version = "0.1", features = ["default"] }
 tokio = { version = "1.52.3", features = ["full"] }
 genai = "0.6.5"
-falkordb = { version = "0.3.0", features = ["tokio"] }
+falkordb = { version = "0.8.9", features = ["tokio"] }
 async-trait = "0.1.89"
 futures = "0.3.31"
 regex = "1.12"

--- a/src/core.rs
+++ b/src/core.rs
@@ -4,7 +4,7 @@
 //! in both the standalone HTTP server and library contexts.
 
 use crate::chat::{ChatRequest, ChatRole};
-use crate::formatter::format_query_records;
+use crate::formatter::{format_query_records, rows_lossy};
 use crate::schema::discovery::Schema;
 use crate::skills::{self, SkillCatalog};
 use crate::template::TemplateEngine;
@@ -558,11 +558,7 @@ fn execute_query_blocking(
                 .map_err(|e| format!("Query execution failed: {e}"))?
         };
 
-        let mut records = Vec::new();
-        for record in query_result.data {
-            records.push(record);
-        }
-        Ok(records)
+        Ok(rows_lossy(query_result.data))
     })
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -13,8 +13,21 @@
 //! - Single record: `[(:Person {name: "John"}), 25, "Engineer"]`
 //! - Multiple records: `1. (:Person {name: "John"})\n2. (:Person {name: "Jane"})`
 
-use falkordb::FalkorValue;
+use falkordb::{FalkorValue, RowStream};
 use std::fmt::Write;
+
+/// Bridges a query result's rows back to the pre-0.7 `Vec<FalkorValue>` shape.
+///
+/// `falkordb` 0.7 made `QueryResult::data` header-aware (yielding `Row`) and 0.8 turned it into a
+/// `Stream` on the async client. This shim restores the flat `Vec<Vec<FalkorValue>>` that the
+/// formatter and schema-discovery code were written against (parse errors collapse to
+/// `FalkorValue::Unparseable`), so the REST/JSON output is unchanged across the upgrade. It is the
+/// single place that performs this conversion — the one thing to revisit when migrating to the
+/// typed, header-aware `Row` API.
+#[must_use]
+pub fn rows_lossy(data: RowStream) -> Vec<Vec<FalkorValue>> {
+    data.into_values_lossy().collect()
+}
 
 /// Formats query results in a compact, LLM-friendly format
 pub fn format_query_records(records: &[Vec<FalkorValue>]) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ mod usage {
 }
 
 use chat::{ChatMessage, ChatRequest, ChatRole};
-use formatter::{format_as_json, format_query_records};
+use formatter::{format_as_json, format_query_records, rows_lossy};
 use mcp::run_mcp_server;
 use template::TemplateEngine;
 use validator::CypherValidator;
@@ -1690,11 +1690,7 @@ fn execute_query_blocking(
                 .map_err(|e| format!("Query execution failed: {e}"))?
         };
 
-        let mut records = Vec::new();
-        for record in query_result.data {
-            records.push(record);
-        }
-        Ok(records)
+        Ok(rows_lossy(query_result.data))
     })
 }
 
@@ -1756,10 +1752,7 @@ fn execute_query_with_csv_import_blocking(
 
         tracing::info!("Query {query} executed, processing results...");
 
-        let mut records = Vec::new();
-        for record in query_result.data {
-            records.push(record);
-        }
+        let records = rows_lossy(query_result.data);
 
         tracing::info!(
             "Query executed successfully with CSV import, records count: {}",
@@ -1824,10 +1817,7 @@ fn execute_query_with_existing_csv_blocking(
 
         tracing::info!("Query {query} executed, processing results...");
 
-        let mut records = Vec::new();
-        for record in query_result.data {
-            records.push(record);
-        }
+        let records = rows_lossy(query_result.data);
 
         tracing::info!(
             "Query executed successfully with existing CSV file, records count: {}",

--- a/src/schema/discovery.rs
+++ b/src/schema/discovery.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use crate::formatter::rows_lossy;
 use falkordb::{AsyncGraph, FalkorDBError, FalkorValue};
 use futures::stream::{self, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -116,7 +117,7 @@ impl Schema {
         let entity_attributes = graph.ro_query(query).execute().await?;
         let mut attributes = Vec::new();
 
-        for record in entity_attributes.data {
+        for record in rows_lossy(entity_attributes.data) {
             // Extract both kt (key-type info) and count from the record
             if let (Some(FalkorValue::Array(kt_array)), Some(FalkorValue::I64(count))) = (record.first(), record.get(1))
             {
@@ -185,7 +186,7 @@ impl Schema {
             match graph.ro_query(&query).execute().await {
                 Ok(result) => {
                     let mut examples = Vec::new();
-                    for record in result.data {
+                    for record in rows_lossy(result.data) {
                         if let Some(FalkorValue::String(value)) = record.first() {
                             examples.push(value.clone());
                         }
@@ -264,7 +265,7 @@ impl Schema {
 
         // Collect labels first to avoid borrowing issues
         let mut entity_labels = Vec::new();
-        for record in labels_result.data {
+        for record in rows_lossy(labels_result.data) {
             if let Some(FalkorValue::String(label)) = record.first() {
                 entity_labels.push(label.clone());
             }
@@ -277,7 +278,7 @@ impl Schema {
         let relations_result = graph.ro_query("CALL db.relationshipTypes()").execute().await?;
 
         let mut relationship_labels = Vec::new();
-        for record in relations_result.data {
+        for record in rows_lossy(relations_result.data) {
             if let Some(FalkorValue::String(relation_label)) = record.first() {
                 relationship_labels.push(relation_label.clone());
             }


### PR DESCRIPTION
Upgrades the `falkordb` Rust client from **0.3.0 → 0.8.9** (the latest). This is **PR-A**: the core,
behavior-preserving bump, deliberately **without** new features (those follow in a small PR-B) so the
dependency jump is easy to review and revert.

## Why this is safe for the dependents
`falkordb` is used **purely internally** (in `core.rs`, `schema/discovery.rs`, `main.rs`, and
`formatter.rs`). It appears in **none** of this project's public contracts:
- the **public Rust API** (`lib.rs`) exposes no falkordb type → `text-to-cypher-node` (napi) and thus
  `falkordb-browser` are unaffected;
- the **REST/JSON responses** are built by `formatter.rs`, which is **unchanged** → `snowflake-integration`
  (Docker image + REST) is unaffected.

## What changed (and what didn't)
Only two falkordb breaking changes affect this codebase:
- **0.7** made `QueryResult::data` header-aware (`Row` instead of `Vec<FalkorValue>`);
- **0.8** made the async result a `Stream` (`RowStream`) instead of an iterator.

Both are bridged by a single new shim, **`formatter::rows_lossy`**, which calls
`RowStream::into_values_lossy()` to restore the exact pre-0.7 `Vec<Vec<FalkorValue>>` rows (parse
errors collapse to `FalkorValue::Unparseable`). All `for record in result.data { … }` sites now go
through it. Everything else is untouched:
- `formatter.rs` value/JSON rendering — **unchanged** (`FalkorValue` variants + `Node`/`Edge`/`Path`
  fields are identical in 0.8.9).
- client construction (`FalkorClientBuilder::new_async()…`), `select_graph`, `query`/`ro_query`,
  `ConfigValue`/`config_get` — **unchanged** (all still present in 0.8.9).
- The **0.6 typed-params** breaking change does **not** apply — queries are raw LLM strings; this
  project never calls `with_param`.

## Validation
- `cargo build`, `cargo test` (**130 pass / 0 fail**, incl. the `formatter` golden-output tests),
  `cargo clippy -- -W clippy::pedantic -W clippy::nursery -D warnings`, and `cargo fmt --check` all green.

## Notes for reviewers
- **MSRV:** falkordb 0.8.9 itself builds fine on rust **1.85** (verified). The project already requires
  **1.88** anyway (via `genai 0.6.5` and this crate's own `let`-chains), and CI builds on `stable`, so
  the `rust-version = "1.85"` in `Cargo.toml` is already stale — unrelated to this bump.
- **Async connection model:** 0.x changed the async default from an exclusive borrow-pool to
  `Multiplexed` (source-compatible, behavior-only). This project builds a short-lived client per
  request, so the practical impact is minimal and it doesn't affect output. Not pinned here; we can
  pin `ConnectionStrategy::Pooled` if exact parity is wanted.

## Follow-ups (not in this PR)
- **PR-B:** opt-in `RetryPolicy` (read-only scope) + enable falkordb's `tracing` feature, via a single
  client-builder helper.
- Later: adopt the typed header-aware `Row` API (would let the JSON carry column names — a *versioned*
  REST change, coordinated with dependents).
- After release: rebuild/publish `text-to-cypher-node` (npm), bump the pinned image tag in
  `snowflake-integration`; `falkordb-browser` auto-updates via its npm range.

> Leaving the merge to a maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated FalkorDB library dependency from version 0.3.0 to 0.8.9

* **Refactor**
  * Streamlined query result conversion and processing logic in core execution paths
  * Consolidated result handling across schema discovery and query execution components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->