### PR TITLE
feat: add read-only retry policy and falkordb tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ dependencies = [
  "strum",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_yaml_ng = "0.10"
 tracing = { version = "0.1", features = ["default"] }
 tokio = { version = "1.52.3", features = ["full"] }
 genai = "0.6.5"
-falkordb = { version = "0.8.9", features = ["tokio"] }
+falkordb = { version = "0.8.9", features = ["tokio", "tracing"] }
 async-trait = "0.1.89"
 futures = "0.3.31"
 regex = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ unsafe_code = "forbid"
 multiple-crate-versions = "allow"
 
 [features]
-default = ["server"]
+default = ["server", "falkordb-tracing"]
+# Emit FalkorDB tracing spans (privacy-safe query fingerprints). Default-on for the binary/Docker
+# image; dependents that build the library with `default-features = false` (e.g. the napi bindings)
+# opt out, keeping their build lean and avoiding the deep async+tracing recursion-limit cost.
+falkordb-tracing = ["falkordb/tracing"]
 server = [
     "dep:actix-web",
     "dep:actix-multipart",
@@ -45,7 +49,7 @@ serde_yaml_ng = "0.10"
 tracing = { version = "0.1", features = ["default"] }
 tokio = { version = "1.52.3", features = ["full"] }
 genai = "0.6.5"
-falkordb = { version = "0.8.9", features = ["tokio", "tracing"] }
+falkordb = { version = "0.8.9", features = ["tokio"] }
 async-trait = "0.1.89"
 futures = "0.3.31"
 regex = "1.12"

--- a/examples/library_usage.rs
+++ b/examples/library_usage.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 //! Example demonstrating how to use text-to-cypher as a library
 //!
 //! This example shows various ways to use the text-to-cypher library

--- a/src/core.rs
+++ b/src/core.rs
@@ -4,36 +4,18 @@
 //! in both the standalone HTTP server and library contexts.
 
 use crate::chat::{ChatRequest, ChatRole};
-use crate::formatter::{format_query_records, rows_lossy};
+use crate::formatter::{build_falkordb_async_client, format_query_records, rows_lossy};
 use crate::schema::discovery::Schema;
 use crate::skills::{self, SkillCatalog};
 use crate::template::TemplateEngine;
 use crate::usage::TokenUsage;
 use crate::validator::CypherValidator;
-use falkordb::{FalkorAsyncClient, FalkorClientBuilder, FalkorConnectionInfo, FalkorResult, RetryPolicy};
+use falkordb::{FalkorAsyncClient, FalkorConnectionInfo};
 use genai::adapter::AdapterKind;
 use genai::chat::ChatMessage as GenAiChatMessage;
 use genai::resolver::{AuthData, AuthResolver, Endpoint, ServiceTargetResolver};
 use genai::{Client as GenAiClient, ModelIden};
 use std::error::Error;
-
-/// Builds an asynchronous `FalkorDB` client with the read-only retry policy applied.
-///
-/// Centralizing client construction here ensures every connection retries only idempotent
-/// read operations (queries issued via `ro_query` and schema discovery) on transient failures,
-/// using exponential backoff. Writes are never retried, so a failed write is surfaced
-/// immediately and can never be duplicated.
-///
-/// # Errors
-///
-/// Returns an error if the client cannot be built (for example, when the connection fails).
-pub async fn build_falkordb_async_client(connection_info: FalkorConnectionInfo) -> FalkorResult<FalkorAsyncClient> {
-    FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .with_retry_policy(RetryPolicy::read_only())
-        .build()
-        .await
-}
 
 /// Discovers the graph schema and returns it as a JSON string
 ///

--- a/src/core.rs
+++ b/src/core.rs
@@ -10,12 +10,30 @@ use crate::skills::{self, SkillCatalog};
 use crate::template::TemplateEngine;
 use crate::usage::TokenUsage;
 use crate::validator::CypherValidator;
-use falkordb::{FalkorAsyncClient, FalkorClientBuilder, FalkorConnectionInfo};
+use falkordb::{FalkorAsyncClient, FalkorClientBuilder, FalkorConnectionInfo, FalkorResult, RetryPolicy};
 use genai::adapter::AdapterKind;
 use genai::chat::ChatMessage as GenAiChatMessage;
 use genai::resolver::{AuthData, AuthResolver, Endpoint, ServiceTargetResolver};
 use genai::{Client as GenAiClient, ModelIden};
 use std::error::Error;
+
+/// Builds an asynchronous `FalkorDB` client with the read-only retry policy applied.
+///
+/// Centralizing client construction here ensures every connection retries only idempotent
+/// read operations (queries issued via `ro_query` and schema discovery) on transient failures,
+/// using exponential backoff. Writes are never retried, so a failed write is surfaced
+/// immediately and can never be duplicated.
+///
+/// # Errors
+///
+/// Returns an error if the client cannot be built (for example, when the connection fails).
+pub async fn build_falkordb_async_client(connection_info: FalkorConnectionInfo) -> FalkorResult<FalkorAsyncClient> {
+    FalkorClientBuilder::new_async()
+        .with_connection_info(connection_info)
+        .with_retry_policy(RetryPolicy::read_only())
+        .build()
+        .await
+}
 
 /// Discovers the graph schema and returns it as a JSON string
 ///
@@ -30,9 +48,7 @@ pub async fn discover_graph_schema(
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
 
@@ -312,9 +328,7 @@ pub async fn execute_cypher_query(
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -13,8 +13,37 @@
 //! - Single record: `[(:Person {name: "John"}), 25, "Engineer"]`
 //! - Multiple records: `1. (:Person {name: "John"})\n2. (:Person {name: "Jane"})`
 
-use falkordb::{FalkorValue, RowStream};
+use falkordb::{
+    FalkorAsyncClient, FalkorClientBuilder, FalkorConnectionInfo, FalkorResult, FalkorValue, RetryPolicy, RowStream,
+};
 use std::fmt::Write;
+
+/// Builds an asynchronous `FalkorDB` client with the read-only retry policy applied.
+///
+/// Centralizing client construction here ensures every connection retries only idempotent
+/// read operations (queries issued via `ro_query` and schema discovery) on transient failures,
+/// using exponential backoff. Writes are never retried, so a failed write is surfaced
+/// immediately and can never be duplicated.
+///
+/// Kept `pub(crate)` so `FalkorDB` types are not exposed in this crate's public API. It lives in
+/// this module (compiled into both the library and the binary) so the binary can share it without
+/// a public re-export.
+///
+/// # Errors
+///
+/// Returns an error if the client cannot be built (for example, when the connection fails).
+// `pub(crate)` keeps FalkorDB types out of the public API in the library (this is a `pub mod`); it
+// looks redundant only in the binary, where `formatter` is a private `mod`.
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) async fn build_falkordb_async_client(
+    connection_info: FalkorConnectionInfo
+) -> FalkorResult<FalkorAsyncClient> {
+    FalkorClientBuilder::new_async()
+        .with_connection_info(connection_info)
+        .with_retry_policy(RetryPolicy::read_only())
+        .build()
+        .await
+}
 
 /// Bridges a query result's rows back to the pre-0.7 `Vec<FalkorValue>` shape.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+#![doc(test(attr(recursion_limit = "256")))]
 //! # text-to-cypher
 //!
 //! A library for translating natural language text to Cypher queries using AI models.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@
 #![allow(clippy::needless_for_each)]
 
 use crate::usage::TokenUsage;
-use ::text_to_cypher::core::{clean_generated_cypher_response, create_genai_client_with_endpoint};
+use ::text_to_cypher::core::{
+    build_falkordb_async_client, clean_generated_cypher_response, create_genai_client_with_endpoint,
+};
 use ::text_to_cypher::skills::{self, SkillCatalog};
 use actix_multipart::Multipart;
 use actix_web::HttpResponse;
@@ -10,7 +12,6 @@ use actix_web::http::StatusCode;
 use actix_web::{App, HttpServer, Responder, Result, post};
 use actix_web_lab::sse::{self, Sse};
 use falkordb::ConfigValue;
-use falkordb::FalkorClientBuilder;
 use falkordb::FalkorConnectionInfo;
 use futures_util::StreamExt;
 use genai::chat::ChatMessage as GenAiChatMessage;
@@ -819,11 +820,7 @@ async fn load_csv_endpoint(req: actix_web::web::Json<LoadCsvRequest>) -> Result<
 
     // List all files in IMPORT_FOLDER at the start
     if let Ok(connection_info) = AppConfig::get().falkordb_connection.as_str().try_into() {
-        if let Ok(client) = FalkorClientBuilder::new_async()
-            .with_connection_info(connection_info)
-            .build()
-            .await
-        {
+        if let Ok(client) = build_falkordb_async_client(connection_info).await {
             match list_import_folder_files(&client).await {
                 Ok(files) => {
                     tracing::info!("Files currently in IMPORT_FOLDER: {:?}", files);
@@ -1411,9 +1408,7 @@ async fn graph_query(
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
     let graph_name = graph_name.to_string();
@@ -1452,9 +1447,7 @@ async fn graph_query_with_csv(
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
 
@@ -1506,9 +1499,7 @@ async fn graph_query_with_existing_csv(
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
 
@@ -1550,9 +1541,7 @@ async fn execute_query(
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
 
@@ -1604,9 +1593,7 @@ async fn get_graphs_list() -> Result<Vec<String>, Box<dyn std::error::Error + Se
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
 
@@ -1638,9 +1625,7 @@ async fn delete_graph(graph_name: &str) -> Result<String, Box<dyn std::error::Er
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
 
@@ -2156,9 +2141,7 @@ async fn discover_graph_schema(
         .try_into()
         .map_err(|e| format!("Invalid connection info: {e}"))?;
 
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .build()
+    let client = build_falkordb_async_client(connection_info)
         .await
         .map_err(|e| format!("Failed to build client: {e}"))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,7 @@
 #![allow(clippy::needless_for_each)]
 
 use crate::usage::TokenUsage;
-use ::text_to_cypher::core::{
-    build_falkordb_async_client, clean_generated_cypher_response, create_genai_client_with_endpoint,
-};
+use ::text_to_cypher::core::{clean_generated_cypher_response, create_genai_client_with_endpoint};
 use ::text_to_cypher::skills::{self, SkillCatalog};
 use actix_multipart::Multipart;
 use actix_web::HttpResponse;
@@ -156,7 +154,7 @@ mod usage {
 }
 
 use chat::{ChatMessage, ChatRequest, ChatRole};
-use formatter::{format_as_json, format_query_records, rows_lossy};
+use formatter::{build_falkordb_async_client, format_as_json, format_query_records, rows_lossy};
 use mcp::run_mcp_server;
 use template::TemplateEngine;
 use validator::CypherValidator;


### PR DESCRIPTION
## Summary

Second PR in the falkordb 0.8 upgrade series (follows #142, the core bump). Adopts two **opt-in falkordb 0.8 resilience/observability features** now that the client is on 0.8.9. **No change to the public Rust API or the REST/JSON contract**, so dependents (`text-to-cypher-node` -> `falkordb-browser`, and `snowflake-integration`) are unaffected.

### 1. Read-only retry policy
- New helper `core::build_falkordb_async_client(connection_info)` centralizes async client construction and applies `RetryPolicy::read_only()` -- 3 attempts, 50 ms -> 1 s exponential backoff with jitter (falkordb defaults).
- **Only idempotent reads are retried.** Under `RetryScope::ReadOnly`, falkordb retries `ro_query`/schema-discovery operations on transient failures and **never retries writes** (`LOAD CSV` / `CREATE` go through `query`), so a failed write cannot be duplicated.
- All **10** builder sites (2 in `core.rs`, 8 in `main.rs`) now go through this single helper -- one place to tune resilience and unit-test parity.
- Scope note (per the falkordb 0.8 retry docs): retry wraps query/procedure **execution** only -- it does not cover `config_get`, `list_graphs`, etc. That is the intended, conservative scope here.

### 2. falkordb `tracing` feature
- Enabled `falkordb`'s `tracing` feature -> OTel-aligned DB spans. text-to-cypher already depends on `tracing` + `tracing-subscriber`, so this is purely additive. **Privacy-safe by default**: spans carry a redacted query *fingerprint*, never raw Cypher or parameter values (`with_query_logging` left off).
- Spans go to the tracing subscriber, **not** the REST response -- the JSON contract is unchanged.
- **Recursion-limit caveat (documented in the falkordb 0.8 guide):** deep async + `tracing::instrument` futures overflow trait evaluation. Fixed by raising `recursion_limit` to 256 on the lib crate root and the `library_usage` example, and injecting it into doctests via `#![doc(test(attr(recursion_limit = "256")))]`. (`main.rs` already had the attribute.)

## Validation
- `cargo fmt -- --check` - pass
- `cargo clippy --all-targets -- -W clippy::pedantic -W clippy::nursery -D warnings` - pass
- `cargo test` - pass: 130 (90 lib + 27 bin + 13 doc), 0 fail, 2 ignored
- `cargo build --release` - pass; `cargo build --examples` - pass
- `Cargo.lock`: +1 line (falkordb gains a `tracing` edge; no new crates -> MSRV/toolchain unaffected)

## Out of scope (deferred per the upgrade plan)
- `metrics` exporter, header-aware Row API (would change REST output shape), `Multiplexed` vs `Pooled` tuning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized async FalkorDB client creation behind a shared helper, applying a consistent read-only retry strategy across discovery and query execution.

* **Chores**
  * Increased Rust recursion limits for the crate and doctests to better support complex types.
  * Enabled an additional tracing-related feature by default to improve runtime observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->