### PR TITLE
chore: release 0.1.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"


### PR DESCRIPTION
## Release 0.1.21

Version bump to publish the **falkordb 0.3.0 → 0.8.9 upgrade** that landed in #142 (core bump) and #143 (read-only RetryPolicy + gated tracing). crates.io `0.1.20` still carries the pre-upgrade falkordb, so a new version is required to ship the upgrade.

### Why a patch bump (0.1.21)
- The **public Rust API and the REST/JSON contract are unchanged** — only internal falkordb usage changed.
- Patch keeps dependents on their existing caret ranges: `text-to-cypher-node`'s `text-to-cypher = "^0.1.19"` auto-resolves `0.1.21` (a `0.2.0` would force a constraint change there).

### What ships in 0.1.21
- falkordb `0.8.9` (was 0.3.0), bridged via the `formatter::rows_lossy` shim — REST output unchanged.
- Read-only `RetryPolicy` on a centralized client builder (retries idempotent reads only; never writes).
- `falkordb/tracing` DB spans, gated behind the default `falkordb-tracing` feature so `default-features = false` consumers (the napi bindings) opt out and stay build-clean.

### Verified
- `cargo fmt` / `clippy --all-targets` (incl. nursery) / 130 tests / default + `--no-default-features` builds — all green.
- **text-to-cypher-node** builds against this crate; generated `index.d.ts` is byte-identical (falkordb-browser's contract intact).

### After merge — release trigger (maintainer action)
Release is **tag-triggered** (`release.yml` on `v*`): tagging `v0.1.21` runs `cargo publish` + binary build, then `docker-release.yml` builds `falkordb/text-to-cypher:0.1.21`. This publish step is irreversible — to be done with explicit go-ahead once this PR is merged. Downstream (node rebuild → npm, snowflake image-tag bump, browser auto-update) follows per `files/t2c-release-runbook.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.1.21

<!-- end of auto-generated comment: release notes by coderabbit.ai -->