### PR TITLE
feat: built-in FalkorDB Cypher context for all consumers (#82)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ ufc.dump
 nodes.csv
 load_data.sh
 .idea
-skills/
+/skills/

--- a/assets/cypher-skills/SOURCE.md
+++ b/assets/cypher-skills/SOURCE.md
@@ -1,0 +1,21 @@
+# Built-in FalkorDB Cypher skills — provenance
+
+These skills are **derived** (not copied verbatim) from FalkorDB's skills repository and the FalkorDB
+documentation, then adapted for read-only natural-language-to-Cypher generation:
+
+- Source: https://github.com/FalkorDB/skills (`cypher-skills/`), ref
+  `172978316e493c48ca352a0be6fb668a9f728855` (the same ref baked into the Docker image's `CYPHER_SKILLS_REF`).
+- Reference docs: https://docs.falkordb.com
+
+## Curation rules (scope: read-only awareness, issue #82 option A)
+- **Pure Cypher only** — upstream examples use `redis-cli GRAPH.QUERY ...`; these are rewritten as the
+  bare Cypher the model should emit.
+- **Read-only only** — DDL/write skills are excluded (range/constraint creation, node/relationship
+  creation, property updates, MERGE). Index *creation* is out of scope; index *querying* is included.
+- **No operational/admin procedures** — `GRAPH.EXPLAIN`/`PROFILE`/`SLOWLOG`/memory inspection are not
+  emitted by the generator; only their query-design guidance is folded into the always-on reference.
+
+These files are embedded at compile time (see `src/skills/builtin.rs`) so every consumer — library, napi
+bindings, browser, and server — gets `FalkorDB`-specific context by default, not just the Docker image.
+The content is hand-curated/derived (not a verbatim copy), so update it deliberately and bump the `ref`
+above when re-deriving from upstream.

--- a/assets/cypher-skills/falkordb-fulltext-search/skill.md
+++ b/assets/cypher-skills/falkordb-fulltext-search/skill.md
@@ -1,0 +1,28 @@
+---
+name: Query FalkorDB full-text indexes
+description: Search text properties with the db.idx.fulltext.queryNodes procedure when a full-text index exists
+---
+
+# Query FalkorDB full-text indexes
+
+Use FalkorDB's full-text search procedure to match text properties with wildcard and fuzzy matching.
+
+## Usage
+
+Only when the ontology declares a full-text index for the label, call
+`db.idx.fulltext.queryNodes('Label', 'search_term')` and yield `node`.
+
+## Example
+
+```cypher
+CALL db.idx.fulltext.queryNodes('Movie', 'Jun*') YIELD node
+RETURN node.title
+```
+
+## Notes
+
+- The search term supports wildcards (e.g. `'Jun*'`) and fuzzy matching.
+- `YIELD node` exposes each matched node; project specific properties in `RETURN`.
+- Use this only when the ontology lists a full-text index for the label; otherwise use a normal
+  `WHERE ... CONTAINS ...` predicate.
+- Full-text search is read-only; it queries an existing index and does not modify the graph.

--- a/assets/cypher-skills/falkordb-index-aware-predicates/skill.md
+++ b/assets/cypher-skills/falkordb-index-aware-predicates/skill.md
@@ -1,0 +1,30 @@
+---
+name: Apply FalkorDB index-aware predicates
+description: Write predicates that let FalkorDB use indexes and avoid full scans in read queries
+---
+
+# Apply FalkorDB index-aware predicates
+
+Design `WHERE` predicates so FalkorDB can use indexes instead of scanning every node.
+
+## Usage
+
+Apply equality or range predicates directly to indexed properties. Avoid not-equal filters and avoid
+wrapping the indexed property in a function.
+
+## Example
+
+```cypher
+MATCH (p:Person)
+WHERE p.age >= 30 AND p.age < 40
+RETURN p.name, p.age
+```
+
+## Notes
+
+- Not-equal (`<>` / `!=`) predicates are not index-accelerated and force a full scan; use them only when
+  exclusion is explicitly required.
+- Equality (`=`) and range (`<`, `<=`, `>`, `>=`) predicates on indexed properties can use an index scan.
+- Applying a function to the indexed property (e.g. `toLower(p.name) = 'alice'`) prevents index use; keep
+  the indexed property bare on one side of the predicate when an index exists.
+- Prefer positive predicates that preserve the question's intent over negations.

--- a/assets/cypher-skills/falkordb-parameterized-queries/skill.md
+++ b/assets/cypher-skills/falkordb-parameterized-queries/skill.md
@@ -1,0 +1,28 @@
+---
+name: Use FalkorDB parameterized queries
+description: Prefix read queries with CYPHER parameters for plan caching and safer value handling
+---
+
+# Use FalkorDB parameterized queries
+
+Pass user-supplied values as parameters so FalkorDB can cache and reuse the query plan.
+
+## Usage
+
+Prefix the query with `CYPHER` and `name=value` declarations, then reference each value with `$name`
+inside the query body.
+
+## Example
+
+```cypher
+CYPHER name='Alice'
+MATCH (u:User {name: $name})
+RETURN u.id
+```
+
+## Notes
+
+- Parameters let FalkorDB cache and reuse query execution plans, avoiding repeated parsing and planning.
+- Declare values after the `CYPHER` keyword using `name=value`; reference them as `$name`.
+- Prefer parameters for user-supplied values; this also avoids query-injection issues.
+- Parameterization does not change the result shape; it only affects planning and safety.

--- a/assets/cypher-skills/falkordb-path-finding/skill.md
+++ b/assets/cypher-skills/falkordb-path-finding/skill.md
@@ -1,0 +1,29 @@
+---
+name: Find paths in FalkorDB
+description: Use variable-length patterns, shortest-path functions, and weighted path procedures in read queries
+---
+
+# Find paths in FalkorDB
+
+Traverse relationships with variable-length patterns and FalkorDB's path-finding functions and procedures.
+
+## Usage
+
+Use variable-length relationship patterns and `shortestPath`/`allShortestPaths` for unweighted paths, and
+the `algo.SPpaths`/`algo.SSpaths` procedures for weighted paths.
+
+## Example
+
+```cypher
+MATCH path = allShortestPaths((a:City {name: 'Paris'})-[:ROAD*]->(b:City {name: 'Berlin'}))
+RETURN [n IN nodes(path) | n.name] AS route
+```
+
+## Notes
+
+- Variable-length paths use `-[:TYPE*minHops..maxHops]->`; bound the hops to avoid expensive traversals.
+- `shortestPath(...)` returns one shortest path; `allShortestPaths(...)` returns every shortest path.
+- For weighted shortest paths use the procedures `algo.SPpaths()` (single pair) and `algo.SSpaths()`
+  (single source).
+- Use `-[:TYPE]-` for undirected traversal and `<-[:TYPE]-` to follow relationships in reverse.
+- These are all read-only traversals.

--- a/assets/cypher-skills/falkordb-vector-search/skill.md
+++ b/assets/cypher-skills/falkordb-vector-search/skill.md
@@ -1,0 +1,28 @@
+---
+name: Query FalkorDB vector indexes
+description: Find nearest-neighbor nodes with the db.idx.vector.queryNodes procedure when a vector index exists
+---
+
+# Query FalkorDB vector indexes
+
+Use FalkorDB's vector search procedure to find approximate nearest neighbors by embedding similarity.
+
+## Usage
+
+Only when the ontology declares a vector index for the label and property, call
+`db.idx.vector.queryNodes('Label', 'property', k, vecf32([...]))` and yield `node, score`.
+
+## Example
+
+```cypher
+CALL db.idx.vector.queryNodes('Product', 'embedding', 5, vecf32([0.1, 0.2, 0.3])) YIELD node, score
+RETURN node.name, score
+```
+
+## Notes
+
+- `k` is the number of nearest neighbors to return; results are ordered by similarity.
+- Pass the query vector with `vecf32([...])`.
+- `YIELD node, score` exposes each match and its similarity score.
+- Use this only when the ontology lists a vector index for the label and property.
+- Vector search is read-only; it queries an existing index and does not modify the graph.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ A high-performance Rust library and API service that translates natural language
 
 ## ✨ What's New
 
-**Dynamic Cypher Skills**: Load FalkorDB-specific Cypher best practices at runtime from external skill files. The LLM can request detailed skill content on-demand via tool calling, keeping prompts compact while enabling deep expertise when needed. See [Dynamic Cypher Skills](#dynamic-cypher-skills) for details.
+**FalkorDB Cypher Skills**: Curated, read-only FalkorDB-specific Cypher best practices are **built in by default** (and extensible from external skill files). The LLM can request detailed skill content on-demand via tool calling, keeping prompts compact while enabling deep expertise when needed. See [Dynamic Cypher Skills](#dynamic-cypher-skills) for details.
 
 **Library Support**: Now available as a Rust library! Use text-to-cypher directly in your Rust applications without the REST API overhead.
 
@@ -37,7 +37,7 @@ A high-performance Rust library and API service that translates natural language
 
 ### AI & Quality
 - **AI Model Integration**: Powered by genai for natural language processing with support for multiple providers
-- **Dynamic Cypher Skills**: Load FalkorDB-specific best practices from external skill files with on-demand tool calling
+- **Dynamic Cypher Skills**: Built-in FalkorDB-specific best practices by default, extensible from external skill files, with on-demand tool calling
 - **Schema-Aware Generation**: Uses schema with example values for better query accuracy
 - **Production Ready**: Comprehensive error handling, logging, and robust architecture
 - **Environment Configuration**: Flexible configuration via `.env` file with fallback to request parameters
@@ -879,7 +879,7 @@ The library is published with:
 
 ## Dynamic Cypher Skills
 
-Text-to-cypher supports loading FalkorDB-specific Cypher expertise from external skill files at runtime. This allows the LLM to generate better, more efficient Cypher queries by leveraging domain-specific knowledge about FalkorDB's query engine.
+Text-to-cypher ships a curated set of **read-only, FalkorDB-specific Cypher skills built in** — every consumer (library, napi bindings, browser, and server) gets them by default, with no setup. You can additionally load or override skills from external skill files at runtime. This allows the LLM to generate better, more efficient Cypher queries by leveraging domain-specific knowledge about FalkorDB's query engine.
 
 ### How It Works
 
@@ -1048,6 +1048,10 @@ Prefer: `MATCH (n:Person) WHERE n.age > 30 OR n.age < 30 RETURN n`
 ```
 
 ### Library Usage with Skills
+
+The built-in, read-only FalkorDB skills are enabled **by default** — `TextToCypherClient::new(...)` already
+includes them, so no setup is required. Use `.with_additional_skills(catalog)` to extend them,
+`.with_skills(catalog)` to replace them, or `.without_skills()` to disable them.
 
 **Basic — load skills from a directory:**
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ pub use chat::{ChatMessage, ChatRequest, ChatRole};
 pub use error::ErrorResponse;
 pub use genai::adapter::AdapterKind;
 pub use processor::{TextToCypherRequest, TextToCypherResponse, process_text_to_cypher_with_skills};
-pub use skills::SkillCatalog;
+pub use skills::{SkillCatalog, SkillProfile};
 pub use usage::TokenUsage;
 // Server-specific modules - only when server feature is enabled
 #[cfg(feature = "server")]
@@ -219,6 +219,11 @@ pub struct TextToCypherClient {
 impl TextToCypherClient {
     /// Creates a new `TextToCypherClient`.
     ///
+    /// The client includes the built-in, read-only `FalkorDB` Cypher skills by default, so generated
+    /// queries account for `FalkorDB`-specific syntax without any extra setup. Use
+    /// [`without_skills`](Self::without_skills) to disable them, or
+    /// [`with_additional_skills`](Self::with_additional_skills) to extend them.
+    ///
     /// # Arguments
     ///
     /// * `model` - The AI model to use (e.g., "gpt-4o-mini", "anthropic:claude-3")
@@ -247,7 +252,7 @@ impl TextToCypherClient {
             api_key: api_key.into(),
             falkordb_connection: falkordb_connection.into(),
             llm_endpoint: None,
-            skill_catalog: None,
+            skill_catalog: Some(SkillCatalog::builtin()),
         }
     }
 
@@ -264,7 +269,10 @@ impl TextToCypherClient {
         self
     }
 
-    /// Sets the skill catalog for dynamic Cypher skill loading.
+    /// Replaces the skill catalog used for Cypher skill loading.
+    ///
+    /// This **replaces** the built-in `FalkorDB` skills that [`new`](Self::new) installs by default. To
+    /// keep the built-in skills and add your own, use [`with_additional_skills`](Self::with_additional_skills).
     ///
     /// When set, the AI model can access specialized `FalkorDB` Cypher skills
     /// for better query generation. Providers that support tool calling load
@@ -286,6 +294,27 @@ impl TextToCypherClient {
         catalog: SkillCatalog,
     ) -> Self {
         self.skill_catalog = Some(catalog);
+        self
+    }
+
+    /// Adds `catalog` to the current skills (the built-in `FalkorDB` skills by default), with `catalog`
+    /// overriding any skill that shares an ID.
+    #[must_use]
+    pub fn with_additional_skills(
+        mut self,
+        catalog: SkillCatalog,
+    ) -> Self {
+        self.skill_catalog = Some(match self.skill_catalog.take() {
+            Some(existing) => existing.merged_with(catalog),
+            None => catalog,
+        });
+        self
+    }
+
+    /// Disables all Cypher skills for this client, including the built-in `FalkorDB` skills.
+    #[must_use]
+    pub fn without_skills(mut self) -> Self {
+        self.skill_catalog = None;
         self
     }
 
@@ -564,7 +593,8 @@ mod tests {
         assert_eq!(client.api_key, "key123");
         assert_eq!(client.falkordb_connection, "falkor://localhost:6379");
         assert_eq!(client.llm_endpoint, None);
-        assert!(client.skill_catalog.is_none());
+        // new() installs the built-in FalkorDB skills by default
+        assert!(client.skill_catalog.is_some());
     }
 
     #[test]
@@ -580,6 +610,40 @@ mod tests {
         let catalog = SkillCatalog::empty();
         let client = TextToCypherClient::new("gpt-4o-mini", "key", "falkor://localhost:6379").with_skills(catalog);
         assert!(client.skill_catalog.is_some());
+    }
+
+    #[test]
+    fn test_new_client_includes_builtin_skills() {
+        let client = TextToCypherClient::new("gpt-4o-mini", "key", "falkor://127.0.0.1:6379");
+        let catalog = client.skill_catalog.as_ref().expect("builtin skills by default");
+        assert!(!catalog.is_empty());
+        assert!(catalog.get_skill("falkordb-fulltext-search").is_some());
+    }
+
+    #[test]
+    fn test_without_skills_clears_builtin() {
+        let client = TextToCypherClient::new("m", "k", "falkor://127.0.0.1:6379").without_skills();
+        assert!(client.skill_catalog.is_none());
+    }
+
+    #[test]
+    fn test_with_skills_replaces_builtin() {
+        let client = TextToCypherClient::new("m", "k", "falkor://127.0.0.1:6379").with_skills(SkillCatalog::empty());
+        assert!(client.skill_catalog.as_ref().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_with_additional_skills_keeps_builtin() {
+        let client =
+            TextToCypherClient::new("m", "k", "falkor://127.0.0.1:6379").with_additional_skills(SkillCatalog::empty());
+        assert!(
+            client
+                .skill_catalog
+                .as_ref()
+                .unwrap()
+                .get_skill("falkordb-fulltext-search")
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 use crate::usage::TokenUsage;
 use ::text_to_cypher::core::{clean_generated_cypher_response, create_genai_client_with_endpoint};
-use ::text_to_cypher::skills::{self, SkillCatalog};
+use ::text_to_cypher::skills::{self, SkillCatalog, SkillProfile};
 use actix_multipart::Multipart;
 use actix_web::HttpResponse;
 use actix_web::http::StatusCode;
@@ -192,24 +192,32 @@ impl AppConfig {
 
         let mcp_port = std::env::var("MCP_PORT").ok().and_then(|p| p.parse().ok()).unwrap_or(3001);
 
-        // Load skills from SKILLS_DIR if configured
-        let skill_catalog = std::env::var("SKILLS_DIR").ok().and_then(|dir| {
-            let path = std::path::Path::new(&dir);
-            match SkillCatalog::from_directory(path) {
-                Ok(catalog) if !catalog.is_empty() => {
-                    tracing::info!("Loaded {} skills from {}", catalog.len(), dir);
-                    Some(catalog)
-                }
-                Ok(_) => {
-                    tracing::warn!("SKILLS_DIR set to '{dir}' but no skills were found");
-                    None
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to load skills from {dir}: {e}");
-                    None
+        // Start from the built-in read-only FalkorDB skills, then let SKILLS_DIR override/extend them.
+        // External skills are filtered to the read-only profile so the read-only contract holds for the
+        // operator override too, not just the built-in set.
+        let builtin = SkillCatalog::builtin();
+        let skill_catalog = match std::env::var("SKILLS_DIR").ok() {
+            Some(dir) => {
+                let path = std::path::Path::new(&dir);
+                match SkillCatalog::from_directory(path) {
+                    Ok(catalog) if !catalog.is_empty() => {
+                        let external = catalog.with_profile(SkillProfile::ReadOnly);
+                        let merged = builtin.merged_with(external);
+                        tracing::info!("Loaded {} skills (built-in + SKILLS_DIR {})", merged.len(), dir);
+                        Some(merged)
+                    }
+                    Ok(_) => {
+                        tracing::warn!("SKILLS_DIR set to '{dir}' but no skills were found; using built-in skills");
+                        Some(builtin)
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to load skills from {dir}: {e}; using built-in skills");
+                        Some(builtin)
+                    }
                 }
             }
-        });
+            None => Some(builtin),
+        };
 
         tracing::info!(
             "Loaded configuration - env_file_loaded: {}, default_model: {:?}, rest_port: {}, mcp_port: {}, skills_loaded: {}",

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -134,7 +134,8 @@ pub async fn process_text_to_cypher(
     default_key: Option<String>,
     default_connection: String,
 ) -> TextToCypherResponse {
-    process_text_to_cypher_with_skills(request, default_model, default_key, default_connection, None).await
+    let builtin = SkillCatalog::builtin();
+    process_text_to_cypher_with_skills(request, default_model, default_key, default_connection, Some(&builtin)).await
 }
 
 /// Process a text-to-cypher request with optional dynamic skill support.

--- a/src/skills/builtin.rs
+++ b/src/skills/builtin.rs
@@ -64,6 +64,28 @@ pub(super) fn is_write_skill(id: &str) -> bool {
     WRITE_SKILL_IDS.contains(&id)
 }
 
+/// Returns true if any fenced code block in `content` contains a Cypher write/DDL clause.
+///
+/// Only fenced code blocks are scanned (not prose), so a read-only skill whose notes merely *mention*
+/// write clauses (e.g. "writes such as CREATE are rejected") is not misclassified. This complements the
+/// [`is_write_skill`] ID denylist with a best-effort content check for arbitrary external skills; the
+/// hard read-only boundary remains `GRAPH.RO_QUERY` at execution time.
+#[must_use]
+pub(super) fn teaches_write_cypher(content: &str) -> bool {
+    const WRITE_CLAUSES: &[&str] = &["CREATE", "MERGE", "DELETE", "SET", "REMOVE", "DROP"];
+    let mut in_code_block = false;
+    for segment in content.split("```") {
+        if in_code_block {
+            let normalized = segment.to_uppercase().replace(|c: char| !c.is_ascii_alphanumeric(), " ");
+            if normalized.split_whitespace().any(|word| WRITE_CLAUSES.contains(&word)) {
+                return true;
+            }
+        }
+        in_code_block = !in_code_block;
+    }
+    false
+}
+
 /// Parse the embedded skills into a map keyed by stable ID.
 ///
 /// Embedded assets are validated by tests (`builtin_skills_all_parse`), so a parse failure here means a
@@ -131,5 +153,28 @@ mod tests {
         assert!(is_write_skill("use-merge-to-avoid-duplicates"));
         assert!(!is_write_skill("falkordb-index-aware-predicates"));
         assert!(!is_write_skill("match-patterns-and-return-projections"));
+    }
+
+    #[test]
+    fn teaches_write_cypher_flags_write_code() {
+        assert!(teaches_write_cypher("```cypher\nCREATE (n:X)\n```"));
+        assert!(teaches_write_cypher("```\nMATCH (n) SET n.x = 1 RETURN n\n```"));
+        assert!(teaches_write_cypher("```cypher\nMATCH (n) DETACH DELETE n\n```"));
+    }
+
+    #[test]
+    fn teaches_write_cypher_ignores_prose_and_reads() {
+        // Prose that merely mentions write clauses must not be flagged.
+        assert!(!teaches_write_cypher(
+            "Writes such as CREATE, SET, DELETE, MERGE are rejected by RO_QUERY."
+        ));
+        // Read-only code is not flagged.
+        assert!(!teaches_write_cypher(
+            "```cypher\nMATCH (n:Person) WHERE n.age > 30 RETURN n.name\n```"
+        ));
+        // Identifiers that contain a clause as a substring are not flagged.
+        assert!(!teaches_write_cypher(
+            "```cypher\nMATCH (n) RETURN n.subset, n.created_at\n```"
+        ));
     }
 }

--- a/src/skills/builtin.rs
+++ b/src/skills/builtin.rs
@@ -1,0 +1,135 @@
+//! Compile-time-embedded, curated read-only `FalkorDB` Cypher skills.
+//!
+//! These ship inside the crate so every consumer — library, napi bindings, browser, and server — gets
+//! `FalkorDB`-specific Cypher context by default, not only the Docker image (which loads skills from
+//! `SKILLS_DIR`). See `assets/cypher-skills/SOURCE.md` for provenance and curation rules.
+
+use super::parser::{Skill, parse_skill};
+use std::collections::HashMap;
+
+/// Curated, read-only `FalkorDB` Cypher skills embedded at compile time.
+///
+/// Each entry is `(stable_id, raw skill.md)`. The set is deliberately read-only (issue #82 option A):
+/// no DDL/write or operational/admin skills are bundled.
+const BUILTIN_SKILLS: &[(&str, &str)] = &[
+    (
+        "falkordb-index-aware-predicates",
+        include_str!("../../assets/cypher-skills/falkordb-index-aware-predicates/skill.md"),
+    ),
+    (
+        "falkordb-fulltext-search",
+        include_str!("../../assets/cypher-skills/falkordb-fulltext-search/skill.md"),
+    ),
+    (
+        "falkordb-vector-search",
+        include_str!("../../assets/cypher-skills/falkordb-vector-search/skill.md"),
+    ),
+    (
+        "falkordb-parameterized-queries",
+        include_str!("../../assets/cypher-skills/falkordb-parameterized-queries/skill.md"),
+    ),
+    (
+        "falkordb-path-finding",
+        include_str!("../../assets/cypher-skills/falkordb-path-finding/skill.md"),
+    ),
+];
+
+/// Stable IDs of upstream `FalkorDB/skills` cypher-skills that perform writes/DDL. Under
+/// [`SkillProfile::ReadOnly`] these are filtered out of any externally supplied catalog so the
+/// read-only contract holds for the server's `SKILLS_DIR` override too, not just the built-in set.
+const WRITE_SKILL_IDS: &[&str] = &[
+    "create-range-indexes",
+    "create-and-query-fulltext-indexes",
+    "create-and-query-vector-indexes",
+    "manage-constraints",
+    "create-nodes-and-relationships",
+    "update-and-remove-properties",
+    "use-merge-to-avoid-duplicates",
+];
+
+/// Which skills are eligible for inclusion in the prompt.
+///
+/// Today text-to-cypher only generates read-only queries, so [`SkillProfile::ReadOnly`] is the only
+/// profile. A future write/DDL generation mode would add its own variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SkillProfile {
+    /// Only read-only skills. Known write/DDL skills are filtered out.
+    #[default]
+    ReadOnly,
+}
+
+/// Returns true if `id` names a known write/DDL skill that must be excluded under a read-only profile.
+#[must_use]
+pub(super) fn is_write_skill(id: &str) -> bool {
+    WRITE_SKILL_IDS.contains(&id)
+}
+
+/// Parse the embedded skills into a map keyed by stable ID.
+///
+/// Embedded assets are validated by tests (`builtin_skills_all_parse`), so a parse failure here means a
+/// malformed vendored file slipped through; it is logged and skipped rather than panicking in a
+/// library constructor.
+pub(super) fn builtin_skills() -> HashMap<String, Skill> {
+    let mut skills = HashMap::with_capacity(BUILTIN_SKILLS.len());
+    for (id, raw) in BUILTIN_SKILLS {
+        match parse_skill(id, raw) {
+            Ok(skill) => {
+                skills.insert((*id).to_string(), skill);
+            }
+            Err(e) => {
+                tracing::error!("Built-in skill '{id}' failed to parse: {e}");
+            }
+        }
+    }
+    skills
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_skills_all_parse() {
+        // Guards against vendoring a malformed skill.md: every embedded asset must parse.
+        for (id, raw) in BUILTIN_SKILLS {
+            let skill = parse_skill(id, raw).unwrap_or_else(|e| panic!("built-in skill '{id}' must parse: {e}"));
+            assert_eq!(&skill.id, id);
+            assert!(!skill.name.trim().is_empty(), "skill '{id}' has empty name");
+            assert!(
+                !skill.description.trim().is_empty(),
+                "skill '{id}' has empty description"
+            );
+            assert!(!skill.content.trim().is_empty(), "skill '{id}' has empty body");
+        }
+    }
+
+    #[test]
+    fn builtin_skills_are_read_only() {
+        // None of the bundled skills may be a known write/DDL skill, and none should teach write clauses.
+        for (id, raw) in BUILTIN_SKILLS {
+            assert!(!is_write_skill(id), "built-in skill '{id}' is a write skill");
+            let upper = raw.to_uppercase();
+            for clause in ["CREATE ", "MERGE ", "DELETE ", " SET ", "REMOVE ", "DROP "] {
+                assert!(
+                    !upper.contains(clause),
+                    "built-in skill '{id}' must not contain write clause {clause:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn builtin_skills_loads_expected_count() {
+        let skills = builtin_skills();
+        assert_eq!(skills.len(), BUILTIN_SKILLS.len());
+        assert!(skills.contains_key("falkordb-fulltext-search"));
+    }
+
+    #[test]
+    fn write_skill_denylist_matches_upstream_ids() {
+        assert!(is_write_skill("create-range-indexes"));
+        assert!(is_write_skill("use-merge-to-avoid-duplicates"));
+        assert!(!is_write_skill("falkordb-index-aware-predicates"));
+        assert!(!is_write_skill("match-patterns-and-return-projections"));
+    }
+}

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -1,6 +1,8 @@
+mod builtin;
 mod loader;
 mod parser;
 
+pub use builtin::SkillProfile;
 pub use loader::SkillCatalog;
 pub use parser::Skill;
 
@@ -35,6 +37,44 @@ impl SkillCatalog {
     #[must_use]
     pub fn empty() -> Self {
         Self { skills: HashMap::new() }
+    }
+
+    /// Build a catalog from the curated, read-only `FalkorDB` Cypher skills embedded in the binary.
+    ///
+    /// Unlike [`from_directory`](Self::from_directory) this needs no filesystem access, so library,
+    /// napi, and browser consumers get `FalkorDB`-specific context by default — not only the Docker
+    /// image (which loads skills from `SKILLS_DIR`).
+    #[must_use]
+    pub fn builtin() -> Self {
+        Self {
+            skills: builtin::builtin_skills(),
+        }
+    }
+
+    /// Merge `other` into this catalog, returning the combined catalog. Skills in `other` override
+    /// skills already present under the same ID.
+    #[must_use]
+    pub fn merged_with(
+        mut self,
+        other: Self,
+    ) -> Self {
+        self.skills.extend(other.skills);
+        self
+    }
+
+    /// Drop any skills not permitted under `profile`.
+    ///
+    /// Under [`SkillProfile::ReadOnly`] known write/DDL skills are removed, so an externally supplied
+    /// catalog (e.g. the server's `SKILLS_DIR`) cannot reintroduce write instructions into the prompt.
+    #[must_use]
+    pub fn with_profile(
+        mut self,
+        profile: SkillProfile,
+    ) -> Self {
+        match profile {
+            SkillProfile::ReadOnly => self.skills.retain(|id, _| !builtin::is_write_skill(id)),
+        }
+        self
     }
 
     /// Render a compact catalog for inclusion in the system prompt.
@@ -247,6 +287,101 @@ const fn is_tool_capable_adapter(kind: genai::adapter::AdapterKind) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_builtin_catalog_loads_read_only_skills() {
+        let catalog = SkillCatalog::builtin();
+        assert!(!catalog.is_empty());
+        assert_eq!(catalog.len(), 5);
+        for id in [
+            "falkordb-index-aware-predicates",
+            "falkordb-fulltext-search",
+            "falkordb-vector-search",
+            "falkordb-parameterized-queries",
+            "falkordb-path-finding",
+        ] {
+            assert!(catalog.get_skill(id).is_some(), "missing built-in skill {id}");
+        }
+        assert!(catalog.render_catalog().contains("falkordb-fulltext-search"));
+    }
+
+    #[test]
+    fn test_with_profile_read_only_filters_write_skills() {
+        let mut skills = HashMap::new();
+        skills.insert(
+            "create-range-indexes".to_string(),
+            Skill {
+                id: "create-range-indexes".to_string(),
+                name: "Create range indexes".to_string(),
+                description: "DDL".to_string(),
+                content: "creates an index".to_string(),
+            },
+        );
+        skills.insert(
+            "match-patterns-and-return-projections".to_string(),
+            Skill {
+                id: "match-patterns-and-return-projections".to_string(),
+                name: "Match patterns".to_string(),
+                description: "read".to_string(),
+                content: "MATCH (n) RETURN n".to_string(),
+            },
+        );
+        let catalog = SkillCatalog { skills }.with_profile(SkillProfile::ReadOnly);
+
+        assert!(catalog.get_skill("create-range-indexes").is_none());
+        assert!(catalog.get_skill("match-patterns-and-return-projections").is_some());
+    }
+
+    #[test]
+    fn test_merged_with_overrides_by_id() {
+        let mut base = HashMap::new();
+        base.insert(
+            "a".to_string(),
+            Skill {
+                id: "a".to_string(),
+                name: "Base A".to_string(),
+                description: "base".to_string(),
+                content: "base".to_string(),
+            },
+        );
+        let mut other = HashMap::new();
+        other.insert(
+            "a".to_string(),
+            Skill {
+                id: "a".to_string(),
+                name: "Override A".to_string(),
+                description: "override".to_string(),
+                content: "override".to_string(),
+            },
+        );
+        other.insert(
+            "b".to_string(),
+            Skill {
+                id: "b".to_string(),
+                name: "B".to_string(),
+                description: "b".to_string(),
+                content: "b".to_string(),
+            },
+        );
+
+        let merged = SkillCatalog { skills: base }.merged_with(SkillCatalog { skills: other });
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged.get_skill("a").unwrap().name, "Override A");
+        assert!(merged.get_skill("b").is_some());
+    }
+
+    #[test]
+    fn test_builtin_render_all_content_within_budget() {
+        // Non-tool providers inline the full built-in bodies; guard against unbounded prompt growth.
+        let rendered = SkillCatalog::builtin().render_all_content();
+        assert!(!rendered.is_empty());
+        assert!(
+            rendered.len() < 8_000,
+            "built-in inline content too large: {} bytes",
+            rendered.len()
+        );
+    }
 
     #[test]
     fn test_empty_catalog() {

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -46,9 +46,14 @@ impl SkillCatalog {
     /// image (which loads skills from `SKILLS_DIR`).
     #[must_use]
     pub fn builtin() -> Self {
-        Self {
-            skills: builtin::builtin_skills(),
-        }
+        // Parse the embedded skills once, then clone the cached catalog. `builtin()` is on the
+        // per-request hot path (e.g. `process_text_to_cypher`), so avoid re-parsing YAML each call.
+        static BUILTIN: std::sync::OnceLock<SkillCatalog> = std::sync::OnceLock::new();
+        BUILTIN
+            .get_or_init(|| Self {
+                skills: builtin::builtin_skills(),
+            })
+            .clone()
     }
 
     /// Merge `other` into this catalog, returning the combined catalog. Skills in `other` override
@@ -72,7 +77,9 @@ impl SkillCatalog {
         profile: SkillProfile,
     ) -> Self {
         match profile {
-            SkillProfile::ReadOnly => self.skills.retain(|id, _| !builtin::is_write_skill(id)),
+            SkillProfile::ReadOnly => self
+                .skills
+                .retain(|id, skill| !builtin::is_write_skill(id) && !builtin::teaches_write_cypher(&skill.content)),
         }
         self
     }
@@ -330,6 +337,34 @@ mod tests {
 
         assert!(catalog.get_skill("create-range-indexes").is_none());
         assert!(catalog.get_skill("match-patterns-and-return-projections").is_some());
+    }
+
+    #[test]
+    fn test_with_profile_filters_content_based_write_skills() {
+        // A skill not in the ID denylist but whose code teaches a write clause is still filtered.
+        let mut skills = HashMap::new();
+        skills.insert(
+            "custom-writer".to_string(),
+            Skill {
+                id: "custom-writer".to_string(),
+                name: "Custom writer".to_string(),
+                description: "not in the ID denylist".to_string(),
+                content: "```cypher\nMATCH (n) SET n.flag = true\n```".to_string(),
+            },
+        );
+        skills.insert(
+            "custom-reader".to_string(),
+            Skill {
+                id: "custom-reader".to_string(),
+                name: "Custom reader".to_string(),
+                description: "read only".to_string(),
+                content: "```cypher\nMATCH (n) RETURN n\n```".to_string(),
+            },
+        );
+        let catalog = SkillCatalog { skills }.with_profile(SkillProfile::ReadOnly);
+
+        assert!(catalog.get_skill("custom-writer").is_none());
+        assert!(catalog.get_skill("custom-reader").is_some());
     }
 
     #[test]

--- a/src/template.rs
+++ b/src/template.rs
@@ -7,6 +7,7 @@ impl TemplateEngine {
     const SYSTEM_PROMPT: &'static str = include_str!("../templates/system_prompt.txt");
     const USER_PROMPT: &'static str = include_str!("../templates/user_prompt.txt");
     const LAST_REQUEST_PROMPT: &'static str = include_str!("../templates/last_request_prompt.txt");
+    const FALKORDB_REFERENCE: &'static str = include_str!("../templates/falkordb_reference.txt");
 
     #[must_use]
     pub fn render(
@@ -39,6 +40,7 @@ impl TemplateEngine {
         let mut variables = HashMap::new();
         variables.insert("ONTOLOGY", ontology);
         variables.insert("SKILLS_CATALOG", skills_catalog);
+        variables.insert("FALKORDB_REFERENCE", Self::FALKORDB_REFERENCE);
         let rendered = Self::render(Self::SYSTEM_PROMPT, &variables);
 
         if !skills_catalog.trim().is_empty() {
@@ -91,5 +93,30 @@ impl TemplateEngine {
         variables.insert("CYPHER_RESULT", cypher_result);
         variables.insert("USER_QUESTION", question);
         Self::render(Self::LAST_REQUEST_PROMPT, &variables)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_prompt_includes_falkordb_reference() {
+        let prompt = TemplateEngine::render_system_prompt("{}");
+        assert!(prompt.contains("db.idx.fulltext.queryNodes"));
+        assert!(prompt.contains("db.idx.vector.queryNodes"));
+        assert!(prompt.contains("algo.SPpaths"));
+        assert!(!prompt.contains("{{FALKORDB_REFERENCE}}"));
+        assert!(!prompt.contains("{{ONTOLOGY}}"));
+        assert!(!prompt.contains("{{SKILLS_CATALOG}}"));
+    }
+
+    #[test]
+    fn system_prompt_with_skills_includes_catalog_and_reference() {
+        let prompt = TemplateEngine::render_system_prompt_with_skills("{}", "Available skills:\n- foo: bar");
+        assert!(prompt.contains("db.idx.fulltext.queryNodes"));
+        assert!(prompt.contains("Available skills:"));
+        assert!(!prompt.contains("{{SKILLS_CATALOG}}"));
+        assert!(!prompt.contains("{{FALKORDB_REFERENCE}}"));
     }
 }

--- a/templates/falkordb_reference.txt
+++ b/templates/falkordb_reference.txt
@@ -1,0 +1,26 @@
+FalkorDB-Specific Cypher (read-only):
+
+Index-aware predicates:
+1. Not-equal operators (<> and !=) are NOT index-accelerated and trigger full scans. Prefer positive equality or range predicates; use <> / != only when exclusion is explicitly required by the question.
+2. Equality (=) and range (<, <=, >, >=) predicates on indexed properties use index scans. Apply predicates directly to the indexed property; wrapping it in a function (e.g. toLower(p.name) = ...) prevents index use.
+
+Full-text search (only when the ontology declares a full-text index):
+CALL db.idx.fulltext.queryNodes('Label', 'search_term') YIELD node
+Supports wildcard (e.g. 'Jun*') and fuzzy matching.
+
+Vector search (only when the ontology declares a vector index):
+CALL db.idx.vector.queryNodes('Label', 'property', k, vecf32([...])) YIELD node, score
+Returns the k approximate nearest neighbors ordered by similarity.
+
+Parameterized queries (plan caching + safety):
+Prefix with CYPHER and declare values, then reference them with $name:
+CYPHER name='Alice' MATCH (u:User {name: $name}) RETURN u.id
+Prefer parameters for user-supplied values.
+
+Paths and traversal:
+- Variable-length paths: -[:TYPE*minHops..maxHops]->
+- Undirected / reverse: -[:TYPE]- or <-[:TYPE]-
+- Optional matching: OPTIONAL MATCH for non-required relationships
+- Named paths: path = (a)-[:REL]->(b)
+- Shortest paths: shortestPath(...) and allShortestPaths((a)-[:REL*]->(b))
+- Weighted shortest paths (procedures): algo.SPpaths() (single pair), algo.SSpaths() (single source)

--- a/templates/system_prompt.txt
+++ b/templates/system_prompt.txt
@@ -28,21 +28,9 @@ Use appropriate relationship types exactly as specified
 For bidirectional queries, specify direction explicitly or use undirected syntax when appropriate
 Self-referencing relationships (same entity label for source and target) are still directed — respect the arrow direction in the ontology unless the question explicitly asks for both directions
 
-FalkorDB-Specific Rules:
-1. Not-equal operators (<> and !=) are NOT index-accelerated and trigger full scans. Prefer positive predicates when they preserve the user's intent. Use <> / != only when exclusion is explicitly required by the question.
-2. Full-text search: If the ontology declares full-text indexes, use CALL db.idx.fulltext.queryNodes('Label', 'search_term') YIELD node to perform text search with wildcard and fuzzy matching. Only use when the ontology explicitly lists a full-text index.
-3. Vector search: If the ontology declares vector indexes, use CALL db.idx.vector.queryNodes('Label', 'property', k, vecf32([...])) YIELD node, score for approximate nearest neighbor search. Only use when the ontology explicitly lists a vector index.
-4. Parameterized queries: FalkorDB supports the CYPHER keyword prefix for parameters (e.g., CYPHER name='Alice' MATCH (u:User {name: $name}) RETURN u). Consider using parameters for user-supplied values when appropriate.
+{{FALKORDB_REFERENCE}}
 
 {{SKILLS_CATALOG}}
-
-Advanced Features Available:
-Variable length paths: -[:TYPE*minHops..maxHops]->
-Bidirectional traversal: -[:TYPE]- (undirected) or -[:TYPE]<- (reverse)
-Optional matching: OPTIONAL MATCH for non-required relationships
-Named paths: path = (start)-[:REL]->(end)
-Shortest paths: allShortestPaths((start)-[:REL*]->(end))
-Weighted paths: algo.SPpaths() for single-pair, algo.SSpaths() for single-source
 
 Value Matching Best Practices:
 When matching property values, prefer exact matches when examples are provided


### PR DESCRIPTION
Closes #82.

## Problem
FalkorDB-specific Cypher guidance (index/procedure querying, parameter prefix, `<>` non-indexing, path finding) reached the LLM **only in the Docker/server path** — skills are loaded from `SKILLS_DIR`, which is read solely by the server `main.rs`. The library API defaulted to no skills; the napi addon (`text-to-cypher-node`) never sets `SKILLS_DIR` or `.with_skills()`; and **falkordb-browser** (in-process napi) defines no `SKILLS_DIR`. So library, napi, and browser consumers got none of it.

## What this does (scope: read-only awareness — issue #82 option A)
Bundles read-only FalkorDB context into the crate so **every consumer** (library, napi, browser, server) gets it by default. No DDL is generated (the tool remains read-only).

**Three layers**
1. **Always-on reference** — `templates/falkordb_reference.txt` is embedded and injected into the system prompt for every request and provider (reaches non-tool models + browser cheaply). Replaces the smaller hand-written block in `system_prompt.txt`.
2. **Built-in skill catalog** — a curated read-only set (`assets/cypher-skills/`) is embedded and exposed via `SkillCatalog::builtin()`; tool-capable models lazy-load full content via the existing `read_skill` tool.
3. **Read-only profile** — `SkillProfile::ReadOnly` filters known write/DDL skills out of any externally supplied catalog (including the server's `SKILLS_DIR`), so the read-only contract holds everywhere — addressing the rubber-duck "external can reintroduce DDL" finding.

**Default-on with opt-out**
- `TextToCypherClient::new()` now includes the built-in skills. Added `without_skills()` and `with_additional_skills()`; kept `with_skills()` (replace).
- `process_text_to_cypher` defaults to built-in; the server uses built-in as the base and merges a read-only-filtered `SKILLS_DIR` on top.
- **Not feature-gated** (napi builds `default-features = false`), so the browser benefits after the next node rebuild — no node code change.

## Curation
Skills are **derived** (pure Cypher; no `redis-cli`/DDL/`EXPLAIN`) from `FalkorDB/skills` + docs.falkordb.com — see `assets/cypher-skills/SOURCE.md`. Admin/diagnostic and write skills are intentionally excluded.

## Tests (+16)
Built-in assets all parse and are read-only; read-only profile filtering; merge/override by ID; client default/replace/extend/disable; prompt assembly includes the reference and catalog; a non-tool inline-content **token-budget guard**.

## Validation
- `cargo fmt -- --check`, `cargo clippy --all-targets -- -W pedantic -W nursery -D warnings` — clean.
- `cargo test` — 146 pass (104 lib + 29 bin + 13 doc), 0 fail.
- `cargo build` and `cargo build --no-default-features` — green.
- `text-to-cypher-node` compiles against this crate; embedded assets ship in `cargo package --list`.

## Notes / out of scope
- DDL generation (`CREATE INDEX`, constraints) is a deliberate **future** mode (option B) requiring a separate non-read-only generation path; `SkillProfile` is structured to add it later.
- The Docker image still loads upstream `SKILLS_DIR` as an operator override (now read-only-filtered); switching it to built-in-only is a possible follow-up.
- **Sequencing:** best merged after the falkordb 0.8.9 release chain (#144 + node rebuild); the browser then picks this up on the same node rebuild.
