### PR TITLE
fix(udf): honor explicit UDF requests and keep answers in prose

### DIFF
--- a/src/udf.rs
+++ b/src/udf.rs
@@ -199,6 +199,10 @@ impl UdfCatalog {
             "Use ONLY the functions listed below; never invent a UDF. If none is clearly relevant to the question, write normal Cypher."
                 .to_string(),
         );
+        lines.push(
+            "When the question explicitly names one of these functions or libraries, or asks to \"use\" a listed function, you MUST call that UDF as library.function(...) in the generated query — do not substitute a built-in operator or equivalent expression."
+                .to_string(),
+        );
 
         let mut libraries: Vec<&UdfLibrary> = self.libraries.iter().filter(|lib| !lib.functions.is_empty()).collect();
         libraries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -473,6 +477,8 @@ mod tests {
 
         assert!(rendered.contains("Use ONLY the functions listed below; never invent a UDF."));
         assert!(rendered.contains("Signatures are not provided"));
+        // An explicit request to use a listed UDF must be honored over a built-in equivalent.
+        assert!(rendered.contains("you MUST call that UDF as library.function(...)"));
         // Libraries and functions are sorted; alib before zlib, A before B.
         let a_pos = rendered.find("- alib.A").unwrap();
         let b_pos = rendered.find("- alib.B").unwrap();

--- a/templates/last_request_prompt.txt
+++ b/templates/last_request_prompt.txt
@@ -1,2 +1,5 @@
-Given that the data from this cypher query {{CYPHER_QUERY}} is {{CYPHER_RESULT}} answer this: {{USER_QUESTION}}
-In your answer do not mention the given data or the cypher query nor the cypher result
+You are answering a user's question. The data needed to answer it was already retrieved by running the cypher query {{CYPHER_QUERY}}, which returned {{CYPHER_RESULT}}.
+
+Using that data, write a clear, natural-language answer to: {{USER_QUESTION}}
+
+Answer in plain prose only. Even if the question is phrased as a request to "return", "generate", "write", or "show" a query, do NOT output any cypher, query, or code — respond with the actual answer derived from the data. Do not mention the given data, the cypher query, or the cypher result.


### PR DESCRIPTION
## What

Two prompt/template fixes for the UDF chat flow, found while testing UDF support end-to-end through `text-to-cypher-node` + falkordb-browser.

### 1. Honor explicitly-requested UDFs (`src/udf.rs`)
When the question explicitly names a listed function/library (or asks to *"use"* one), the model must call it as `library.function(...)` instead of substituting a built-in equivalent.

- **Before:** *"use mathlib.multiply to compute price times quantity"* generated `RETURN p.price * p.quantity` — the UDF was ignored in favor of `*`.
- **After:** generates `RETURN mathlib.multiply(p.price, p.quantity)`.

The existing "if none is clearly relevant, write normal Cypher" guidance is preserved, so non-UDF questions are unaffected.

### 2. Keep final answers in prose (`templates/last_request_prompt.txt`)
The answer step now always returns a natural-language answer derived from the results and never emits Cypher/code — even when the question is phrased as *"return/generate/show ..."*.

- **Before:** the final answer could come back as a Cypher query instead of an explanation.
- **After:** prose answer (e.g. "Apple: 30, Banana: 50, ...").

## Testing

- `cargo test --lib` → **135 passed** (added a render() assertion for the new UDF directive).
- Live end-to-end (gpt-4o-mini, real FalkorDB) via the rebuilt node binding:
  - UDF question (with udfs) → executed query uses `mathlib.multiply(...)`, answer is prose ✅
  - Non-UDF question with udfs present → normal `count(...)` query, no forced UDF (regression) ✅
  - Non-UDF question with no udfs → baseline behavior unchanged ✅

## Notes

No logic/source changes in `text-to-cypher-node`. Once released, the node bindings need a dependency bump + rebuild/republish (templates compile into the native binary), then falkordb-browser bumps the npm version.
