### PR TITLE
Prefer algo.SPpaths for shortest-path queries in prompts

### DIFF
--- a/assets/cypher-skills/falkordb-path-finding/skill.md
+++ b/assets/cypher-skills/falkordb-path-finding/skill.md
@@ -1,6 +1,6 @@
 ---
 name: Find paths in FalkorDB
-description: Use variable-length patterns, shortest-path functions, and weighted path procedures in read queries
+description: Use algo.SPpaths/algo.SSpaths procedures and variable-length patterns to find paths in read queries
 ---
 
 # Find paths in FalkorDB
@@ -9,21 +9,29 @@ Traverse relationships with variable-length patterns and FalkorDB's path-finding
 
 ## Usage
 
-Use variable-length relationship patterns and `shortestPath`/`allShortestPaths` for unweighted paths, and
-the `algo.SPpaths`/`algo.SSpaths` procedures for weighted paths.
+Use the `algo.SPpaths` procedure to find the shortest path between two specific nodes (single pair),
+and `algo.SSpaths` for shortest paths from one source to all reachable nodes. Use variable-length
+relationship patterns with `shortestPath`/`allShortestPaths` only for simple unweighted pattern matching.
 
 ## Example
 
 ```cypher
-MATCH path = allShortestPaths((a:City {name: 'Paris'})-[:ROAD*]->(b:City {name: 'Berlin'}))
+MATCH (a:City {name: 'Paris'}), (b:City {name: 'Berlin'})
+CALL algo.SPpaths({sourceNode: a, targetNode: b, relTypes: ['ROAD'], relDirection: 'outgoing', pathCount: 1})
+YIELD path
 RETURN [n IN nodes(path) | n.name] AS route
 ```
 
 ## Notes
 
+- Prefer `algo.SPpaths()` for "shortest path between X and Y" questions; it is FalkorDB's dedicated
+  single-pair shortest-path procedure.
+- Parameters: `sourceNode`, `targetNode`, `relTypes` (array), `relDirection` (`outgoing` | `incoming` | `both`),
+  `pathCount` (1 = single shortest, 0 = all shortest, n = up to n paths).
+- Add `weightProp` (e.g. `'dist'`, `'time'`) to minimize a weighted property, and `costProp`/`maxCost`
+  to constrain total cost. It `YIELD`s `path`, `pathWeight`, and `pathCost`.
+- Use `algo.SSpaths()` (single source) for shortest paths from one node to all reachable destinations.
 - Variable-length paths use `-[:TYPE*minHops..maxHops]->`; bound the hops to avoid expensive traversals.
-- `shortestPath(...)` returns one shortest path; `allShortestPaths(...)` returns every shortest path.
-- For weighted shortest paths use the procedures `algo.SPpaths()` (single pair) and `algo.SSpaths()`
-  (single source).
+- `shortestPath(...)`/`allShortestPaths(...)` are unweighted pattern helpers for simple cases.
 - Use `-[:TYPE]-` for undirected traversal and `<-[:TYPE]-` to follow relationships in reverse.
 - These are all read-only traversals.

--- a/assets/cypher-skills/falkordb-path-finding/skill.md
+++ b/assets/cypher-skills/falkordb-path-finding/skill.md
@@ -30,7 +30,7 @@ RETURN [n IN nodes(path) | n.name] AS route
   `pathCount` (1 = single shortest, 0 = all shortest, n = up to n paths).
 - Add `weightProp` (e.g. `'dist'`, `'time'`) to minimize a weighted property, and `costProp`/`maxCost`
   to constrain total cost. It `YIELD`s `path`, `pathWeight`, and `pathCost`.
-- Use `algo.SSpaths()` (single source) for shortest paths from one node to all reachable destinations.
+- Use `algo.SSpaths()` (single source) for all shortest paths from one node to all reachable destinations.
 - Variable-length paths use `-[:TYPE*minHops..maxHops]->`; bound the hops to avoid expensive traversals.
 - `shortestPath(...)`/`allShortestPaths(...)` are unweighted pattern helpers for simple cases.
 - Use `-[:TYPE]-` for undirected traversal and `<-[:TYPE]-` to follow relationships in reverse.

--- a/templates/falkordb_reference.txt
+++ b/templates/falkordb_reference.txt
@@ -22,5 +22,10 @@ Paths and traversal:
 - Undirected / reverse: -[:TYPE]- or <-[:TYPE]-
 - Optional matching: OPTIONAL MATCH for non-required relationships
 - Named paths: path = (a)-[:REL]->(b)
-- Shortest paths: shortestPath(...) and allShortestPaths((a)-[:REL*]->(b))
-- Weighted shortest paths (procedures): algo.SPpaths() (single pair), algo.SSpaths() (single source)
+- Shortest path between two specific nodes: prefer the algo.SPpaths() procedure (single pair).
+  Syntax: MATCH (a:Label {..}), (b:Label {..})
+          CALL algo.SPpaths({sourceNode: a, targetNode: b, relTypes: ['REL'], relDirection: 'outgoing', pathCount: 1})
+          YIELD path RETURN path
+  Add weightProp (e.g. 'dist', 'time', 'price') to minimize a weighted property; use pathCount: 0 for all shortest paths.
+- Shortest paths from one source to all reachable nodes: algo.SSpaths() (single source).
+- Unweighted pattern helpers also exist: shortestPath(...) and allShortestPaths((a)-[:REL*]->(b)).


### PR DESCRIPTION
## What

Updates the path-finding prompt assets so the model emits FalkorDB's dedicated path-finding procedures for shortest-path questions:

- `templates/falkordb_reference.txt` — replaces the one-liner with explicit guidance and the documented `algo.SPpaths` call syntax (`sourceNode`/`targetNode`/`relTypes`/`relDirection`/`pathCount`), plus `algo.SSpaths` for single-source.
- `assets/cypher-skills/falkordb-path-finding/skill.md` — new `algo.SPpaths` example (replacing the `allShortestPaths` one), expanded notes, and updated front-matter.

`shortestPath`/`allShortestPaths` are kept as unweighted pattern helpers.

## Why

For questions like "what is the path from TLV to Sydney?" the model previously generated `allShortestPaths(...)`. The [algo.SPpaths](https://docs.falkordb.com/algorithms/sppath.html) procedure is FalkorDB's purpose-built single-pair shortest-path procedure and should be preferred.

## Testing

- `cargo test template::` — 5 passed (includes the `algo.SPpaths` assertion).
- End-to-end with gpt-4o-mini against an `airports` graph: model now generates `algo.SPpaths{...}` (not `allShortestPaths`); the procedure returns the correct path `TLV -> DXB -> SIN -> SYD`.

No code changes; only prompt assets (embedded via `include_str!`). Consumers like text-to-cypher-node only need a version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the FalkorDB “Find paths in read queries” skill guide with clearer guidance to use `algo.SPpaths`/`algo.SSpaths` for shortest-path queries.
  * Revised examples and query flow to better illustrate single-pair and single-source searches, including how to retrieve paths with `YIELD`.
  * Enhanced guidance on choosing unweighted vs. weighted vs. cost-constrained queries, and how to use procedure parameters for weights and limits.
  * Refreshed FalkorDB shortest-path reference text to align with the updated recommendations and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->