### PR TITLE
fix(prompt): return readable node fields for shortest-path queries

### DIFF
--- a/templates/falkordb_reference.txt
+++ b/templates/falkordb_reference.txt
@@ -25,7 +25,8 @@ Paths and traversal:
 - Shortest path between two specific nodes: prefer the algo.SPpaths() procedure (single pair).
   Syntax: MATCH (a:Label {..}), (b:Label {..})
           CALL algo.SPpaths({sourceNode: a, targetNode: b, relTypes: ['REL'], relDirection: 'outgoing', pathCount: 1})
-          YIELD path RETURN path
+          YIELD path, pathWeight RETURN [n IN nodes(path) | n.name] AS route, pathWeight
+  Do NOT return a bare path object (e.g. RETURN path); always project readable node fields such as names so the answer is human-readable.
   Add weightProp (e.g. 'dist', 'time', 'price') to minimize a weighted property; use pathCount: 0 for all shortest paths.
 - Shortest paths from one source to all reachable nodes: algo.SSpaths() (single source).
 - Unweighted pattern helpers also exist: shortestPath(...) and allShortestPaths((a)-[:REL*]->(b)).


### PR DESCRIPTION
## Problem
Shortest-path questions (e.g. "What is the shortest path from city A to city D?") sometimes came back with "I can't determine the shortest path… no valid path output was produced", even though a path exists.

**Root cause:** the `algo.SPpaths` example in `templates/falkordb_reference.txt` taught the model to `YIELD path RETURN path`. A bare `path` object serializes to internal node IDs (e.g. `[(0), [2], (2), [3], (3)]`), which the final-answer step can't interpret — so it reports no path.

This is **not model-specific**: gpt-4o-mini, gpt-4o, and gpt-4.1-mini all reproduced `RETURN path` before the fix.

## Fix
Update the reference example to project readable fields and explicitly forbid returning a bare path object:

```
YIELD path, pathWeight RETURN [n IN nodes(path) | n.name] AS route, pathWeight
```

## Verification
Ran the same question against `path_algo` for all three models via `/text_to_cypher`:
- **Before:** `… YIELD path RETURN path` → "no valid path"
- **After:** `… RETURN [n IN nodes(path) | n.name] AS route, pathWeight` → answer: "The route is A → C → D"

`cargo fmt --check` and template tests pass.

Follow-up to #153.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for shortest-path queries to return a readable route using node names and `pathWeight`.
  * Clarified that results should not return a raw or bare path object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->