### PR TITLE
feat: report answer confidence across REST, library, and MCP

### DIFF
--- a/docs/LIBRARY_API.md
+++ b/docs/LIBRARY_API.md
@@ -327,6 +327,10 @@ pub struct TextToCypherResponse {
     pub cypher_query: Option<String>,
     pub cypher_result: Option<String>,
     pub answer: Option<String>,
+    /// Model self-reported confidence (0-100) that the answer is correct given
+    /// the query results, parsed from a trailing marker and stripped from
+    /// `answer`. Omitted from JSON when the model does not report a value.
+    pub confidence: Option<u8>,
     pub error: Option<String>,
     /// Aggregated token usage across all LLM calls made while serving the request.
     /// Present on successful responses, and also on error responses when at least

--- a/docs/PYTHON_USAGE.md
+++ b/docs/PYTHON_USAGE.md
@@ -64,6 +64,7 @@ class TextToCypherResponse:
     cypher_query: Optional[str] = None
     cypher_result: Optional[str] = None
     answer: Optional[str] = None
+    confidence: Optional[int] = None  # model self-reported confidence (0-100)
     error: Optional[str] = None
 
 class TextToCypherClient:
@@ -131,6 +132,7 @@ class TextToCypherClient:
             cypher_query=data.get("cypher_query"),
             cypher_result=data.get("cypher_result"),
             answer=data.get("answer"),
+            confidence=data.get("confidence"),
             error=data.get("error")
         )
 
@@ -195,6 +197,7 @@ class TextToCypherClient:
             cypher_query=data.get("cypher_query"),
             cypher_result=data.get("cypher_result"),
             answer=data.get("answer"),
+            confidence=data.get("confidence"),
             error=data.get("error")
         )
 

--- a/docs/TYPESCRIPT_USAGE.md
+++ b/docs/TYPESCRIPT_USAGE.md
@@ -59,6 +59,7 @@ interface TextToCypherResponse {
   cypher_query?: string;
   cypher_result?: string;
   answer?: string;
+  confidence?: number; // model self-reported confidence (0-100) in the answer
   error?: string;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ A high-performance Rust library and API service that translates natural language
 - **AI Model Integration**: Powered by genai for natural language processing with support for multiple providers
 - **Dynamic Cypher Skills**: Built-in FalkorDB-specific best practices by default, extensible from external skill files, with on-demand tool calling
 - **Schema-Aware Generation**: Uses schema with example values for better query accuracy
+- **Answer Confidence**: Each answer includes a model self-reported confidence score (0-100), available via the library, REST SSE stream, and MCP tool response
 - **Production Ready**: Comprehensive error handling, logging, and robust architecture
 - **Environment Configuration**: Flexible configuration via `.env` file with fallback to request parameters
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -16,7 +16,34 @@ use genai::adapter::AdapterKind;
 use genai::chat::ChatMessage as GenAiChatMessage;
 use genai::resolver::{AuthData, AuthResolver, Endpoint, ServiceTargetResolver};
 use genai::{Client as GenAiClient, ModelIden};
+use regex::Regex;
 use std::error::Error;
+use std::sync::OnceLock;
+
+/// Matches a trailing `CONFIDENCE: <0-100>` marker emitted by the answer prompt.
+fn confidence_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?is)\s*CONFIDENCE:\s*(\d{1,3})\s*\.?\s*$").expect("valid confidence regex"))
+}
+
+/// Extracts a trailing `CONFIDENCE: <0-100>` marker from an answer.
+///
+/// Returns the answer with the marker removed (trimmed at the end) and the
+/// parsed confidence value clamped to `0..=100`, or `None` if no marker is present.
+#[must_use]
+pub fn parse_answer_confidence(answer: &str) -> (String, Option<u8>) {
+    confidence_regex().captures(answer).map_or_else(
+        || (answer.trim_end().to_string(), None),
+        |caps| {
+            let whole = caps.get(0).map_or(0, |m| m.start());
+            let confidence = caps
+                .get(1)
+                .and_then(|m| m.as_str().parse::<u16>().ok())
+                .map(|v| u8::try_from(v.min(100)).unwrap_or(100));
+            (answer[..whole].trim_end().to_string(), confidence)
+        },
+    )
+}
 
 /// Discovers the graph schema and returns it as a JSON string
 ///
@@ -402,6 +429,30 @@ pub async fn generate_final_answer_with_usage(
     model: &str,
     token_usage: &mut TokenUsage,
 ) -> Result<String, Box<dyn Error + Send + Sync>> {
+    let (answer, _confidence) =
+        generate_final_answer_with_confidence(chat_request, cypher_query, cypher_result, client, model, token_usage)
+            .await?;
+    Ok(answer)
+}
+
+/// Generates a final answer, returning both the prose answer and the model's
+/// self-reported confidence (0-100) that the answer is correct given the data.
+///
+/// The confidence is parsed from a trailing `CONFIDENCE: <0-100>` marker emitted
+/// by the answer prompt and stripped from the returned answer. Returns `None`
+/// when the model does not emit a marker.
+///
+/// # Errors
+///
+/// Returns an error if the AI chat request fails
+pub async fn generate_final_answer_with_confidence(
+    chat_request: &ChatRequest,
+    cypher_query: &str,
+    cypher_result: &str,
+    client: &GenAiClient,
+    model: &str,
+    token_usage: &mut TokenUsage,
+) -> Result<(String, Option<u8>), Box<dyn Error + Send + Sync>> {
     let genai_chat_request = create_answer_chat_request(chat_request, cypher_query, cypher_result);
 
     let chat_response = client
@@ -415,7 +466,7 @@ pub async fn generate_final_answer_with_usage(
         .into_first_text()
         .unwrap_or_else(|| "Unable to generate answer".to_string());
 
-    Ok(answer)
+    Ok(parse_answer_confidence(&answer))
 }
 
 /// Creates a `GenAI` client with optional custom API key
@@ -757,6 +808,23 @@ pub async fn list_all_models_with_endpoint(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_answer_confidence_extracts_and_strips_marker() {
+        let (answer, confidence) = parse_answer_confidence("The route is A to C to D.\nCONFIDENCE: 85");
+        assert_eq!(answer, "The route is A to C to D.");
+        assert_eq!(confidence, Some(85));
+    }
+
+    #[test]
+    fn parse_answer_confidence_clamps_and_handles_missing() {
+        let (_, over) = parse_answer_confidence("Answer. CONFIDENCE: 250");
+        assert_eq!(over, Some(100));
+
+        let (answer, none) = parse_answer_confidence("Just an answer with no marker.");
+        assert_eq!(answer, "Just an answer with no marker.");
+        assert_eq!(none, None);
+    }
 
     #[test]
     fn clean_generated_cypher_response_strips_surrounding_quotes() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,7 @@ enum Progress {
     CypherResult(String),
     ModelOutputChunk(String),
     Result(String),
+    Confidence(u8),
     Usage(TokenUsage),
     Error(String),
 }
@@ -2468,7 +2469,12 @@ async fn process_chat_stream(
     tx: &mpsc::Sender<sse::Event>,
     token_usage: &mut TokenUsage,
 ) -> String {
-    let mut answer = String::new();
+    // Number of trailing bytes withheld from live streaming so a trailing
+    // `CONFIDENCE: <0-100>` marker is never surfaced to the client mid-stream.
+    const HOLD_BYTES: usize = 48;
+
+    let mut full = String::new();
+    let mut sent = 0usize;
 
     // Extract the response stream
     let mut stream = chat_response.stream;
@@ -2485,8 +2491,14 @@ async fn process_chat_stream(
         match stream_event {
             genai::chat::ChatStreamEvent::Start => {}
             genai::chat::ChatStreamEvent::Chunk(chunk) => {
-                answer.push_str(&chunk.content);
-                send_or_empty!(tx, Progress::ModelOutputChunk(chunk.content));
+                full.push_str(&chunk.content);
+                // Stream everything except the last HOLD_BYTES so the marker,
+                // which may be split across chunks, is caught before emission.
+                let safe_end = floor_char_boundary(&full, full.len().saturating_sub(HOLD_BYTES));
+                if safe_end > sent {
+                    send_or_empty!(tx, Progress::ModelOutputChunk(full[sent..safe_end].to_string()));
+                    sent = safe_end;
+                }
             }
             genai::chat::ChatStreamEvent::ReasoningChunk(_chunk) => {}
             genai::chat::ChatStreamEvent::End(end_event) => {
@@ -2499,10 +2511,33 @@ async fn process_chat_stream(
         }
     }
 
-    tracing::info!("Final answer: {}", answer);
+    let (answer, confidence) = ::text_to_cypher::core::parse_answer_confidence(&full);
+
+    // Flush any remaining clean answer text that was held back during streaming.
+    let start = floor_char_boundary(&answer, sent.min(answer.len()));
+    if start < answer.len() {
+        send_or_empty!(tx, Progress::ModelOutputChunk(answer[start..].to_string()));
+    }
+
+    tracing::info!("Final answer: {} (confidence: {:?})", answer, confidence);
     // Emit the aggregated token usage before the terminal Result event so consumers
     // that treat Result as terminal still receive the usage.
     send_or_empty!(tx, Progress::Usage(*token_usage));
+    if let Some(confidence) = confidence {
+        send_or_empty!(tx, Progress::Confidence(confidence));
+    }
     send_or_empty!(tx, Progress::Result(answer.clone()));
     answer
+}
+
+/// Returns the largest byte index `<= index` that lies on a UTF-8 char boundary.
+fn floor_char_boundary(
+    s: &str,
+    index: usize,
+) -> usize {
+    let mut i = index.min(s.len());
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
 }

--- a/src/mcp/server_handler.rs
+++ b/src/mcp/server_handler.rs
@@ -195,6 +195,7 @@ async fn process_sse_response(response: reqwest::Response) -> Result<String, Box
     let mut result_buffer = String::new();
     let mut final_result = String::new();
     let mut token_usage: Option<TokenUsage> = None;
+    let mut confidence: Option<u8> = None;
 
     while let Some(chunk_result) = stream.next().await {
         let chunk = chunk_result?;
@@ -202,7 +203,13 @@ async fn process_sse_response(response: reqwest::Response) -> Result<String, Box
 
         for line in chunk_str.lines() {
             if let Some(data) = line.strip_prefix("data: ") {
-                process_sse_event(data, &mut result_buffer, &mut final_result, &mut token_usage)?;
+                process_sse_event(
+                    data,
+                    &mut result_buffer,
+                    &mut final_result,
+                    &mut token_usage,
+                    &mut confidence,
+                )?;
             }
         }
     }
@@ -211,6 +218,7 @@ async fn process_sse_response(response: reqwest::Response) -> Result<String, Box
         &result_buffer,
         &final_result,
         token_usage.as_ref(),
+        confidence,
     ))
 }
 
@@ -220,6 +228,7 @@ fn process_sse_event(
     result_buffer: &mut String,
     final_result: &mut String,
     token_usage: &mut Option<TokenUsage>,
+    confidence: &mut Option<u8>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Ok(progress) = serde_json::from_str::<serde_json::Value>(data)
         && let Some(event_type) = progress.as_object().and_then(|obj| obj.keys().next())
@@ -231,6 +240,7 @@ fn process_sse_event(
             "CypherResult" => handle_cypher_result_event(&progress, result_buffer),
             "ModelOutputChunk" => handle_model_output_chunk(&progress, final_result),
             "Result" => handle_result_event(&progress, final_result),
+            "Confidence" => handle_confidence_event(&progress, confidence),
             "Usage" => handle_usage_event(&progress, token_usage),
             "Error" => return handle_error_event(&progress),
             _ => tracing::debug!("Unknown event type: {}", event_type),
@@ -294,6 +304,17 @@ fn handle_result_event(
     }
 }
 
+fn handle_confidence_event(
+    progress: &serde_json::Value,
+    confidence: &mut Option<u8>,
+) {
+    if let Some(value) = progress.get("Confidence").and_then(serde_json::Value::as_u64) {
+        let value = u8::try_from(value.min(100)).unwrap_or(100);
+        tracing::info!("Answer confidence: {}", value);
+        *confidence = Some(value);
+    }
+}
+
 fn handle_error_event(progress: &serde_json::Value) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(error) = progress.get("Error").and_then(|v| v.as_str()) {
         tracing::error!("Error from HTTP endpoint: {}", error);
@@ -325,12 +346,17 @@ fn build_complete_response(
     result_buffer: &str,
     final_result: &str,
     token_usage: Option<&TokenUsage>,
+    confidence: Option<u8>,
 ) -> String {
     let mut response = if final_result.is_empty() {
         result_buffer.trim().to_string()
     } else {
         format!("{}\n\nFinal Answer:\n{}", result_buffer.trim(), final_result)
     };
+
+    if let Some(confidence) = confidence {
+        write!(response, "\n\nConfidence: {confidence}%").unwrap();
+    }
 
     if let Some(usage) = token_usage {
         write!(
@@ -377,5 +403,45 @@ async fn get_graph_schema_via_api(graph_name: &str) -> Result<String, Box<dyn st
         Ok(schema)
     } else {
         Err(format!("API returned error status: {}", response.status()).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Feeds the SSE events a real run emits and returns the assembled MCP response.
+    fn assemble(events: &[&str]) -> String {
+        let mut result_buffer = String::new();
+        let mut final_result = String::new();
+        let mut token_usage: Option<TokenUsage> = None;
+        let mut confidence: Option<u8> = None;
+        for data in events {
+            process_sse_event(
+                data,
+                &mut result_buffer,
+                &mut final_result,
+                &mut token_usage,
+                &mut confidence,
+            )
+            .unwrap();
+        }
+        build_complete_response(&result_buffer, &final_result, token_usage.as_ref(), confidence)
+    }
+
+    #[test]
+    fn confidence_event_is_surfaced_in_mcp_response() {
+        let response = assemble(&[r#"{"Result":"The city names are A, B, C, and D."}"#, r#"{"Confidence":100}"#]);
+        assert!(response.contains("Final Answer:\nThe city names are A, B, C, and D."));
+        assert!(response.contains("Confidence: 100%"));
+    }
+
+    #[test]
+    fn confidence_is_omitted_when_absent_and_clamped_when_high() {
+        let without = assemble(&[r#"{"Result":"An answer."}"#]);
+        assert!(!without.contains("Confidence:"));
+
+        let clamped = assemble(&[r#"{"Result":"An answer."}"#, r#"{"Confidence":250}"#]);
+        assert!(clamped.contains("Confidence: 100%"));
     }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -6,7 +6,7 @@
 use crate::chat::ChatRequest;
 use crate::core::{
     create_genai_client_with_endpoint, discover_graph_schema, discover_udfs, execute_cypher_query,
-    generate_cypher_query_with_context_and_usage, generate_final_answer_with_usage,
+    generate_cypher_query_with_context_and_usage, generate_final_answer_with_confidence,
 };
 use crate::skills::SkillCatalog;
 use crate::udf::{UdfError, UdfSource};
@@ -43,6 +43,9 @@ pub struct TextToCypherResponse {
     pub cypher_result: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub answer: Option<String>,
+    /// Model self-reported confidence (0-100) that the answer is correct given the data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// Aggregated token usage across all LLM calls made while serving the request.
@@ -87,6 +90,7 @@ impl TextToCypherResponse {
             cypher_query: Some(cypher_query),
             cypher_result,
             answer,
+            confidence: None,
             error: None,
             token_usage,
         }
@@ -112,6 +116,7 @@ impl TextToCypherResponse {
             cypher_query: None,
             cypher_result: None,
             answer: None,
+            confidence: None,
             error: Some(error_message),
             token_usage,
         }
@@ -309,7 +314,7 @@ pub async fn process_text_to_cypher_with_context(
                 Ok((healed_query, healed_result)) => {
                     tracing::info!("Self-healing successful");
                     // Return the healed version
-                    let answer = match generate_final_answer_with_usage(
+                    let (answer, confidence) = match generate_final_answer_with_confidence(
                         &request.chat_request,
                         &healed_query,
                         &healed_result,
@@ -319,20 +324,22 @@ pub async fn process_text_to_cypher_with_context(
                     )
                     .await
                     {
-                        Ok(a) => Some(a),
+                        Ok((a, c)) => (Some(a), c),
                         Err(e) => {
                             tracing::error!("Failed to generate answer: {}", e);
-                            None
+                            (None, None)
                         }
                     };
 
-                    return TextToCypherResponse::success_with_usage(
+                    let mut response = TextToCypherResponse::success_with_usage(
                         schema,
                         healed_query,
                         Some(healed_result),
                         answer,
                         Some(token_usage),
                     );
+                    response.confidence = confidence;
+                    return response;
                 }
                 Err(heal_error) => {
                     return TextToCypherResponse::error_with_usage(
@@ -347,7 +354,7 @@ pub async fn process_text_to_cypher_with_context(
     tracing::info!("Query executed successfully");
 
     // Step 4: Generate final answer
-    let answer = match generate_final_answer_with_usage(
+    let (answer, confidence) = match generate_final_answer_with_confidence(
         &request.chat_request,
         &cypher_query,
         &cypher_result,
@@ -357,7 +364,7 @@ pub async fn process_text_to_cypher_with_context(
     )
     .await
     {
-        Ok(a) => Some(a),
+        Ok((a, c)) => (Some(a), c),
         Err(e) => {
             return TextToCypherResponse::error_with_usage(
                 format!("Failed to generate answer: {e}"),
@@ -366,7 +373,10 @@ pub async fn process_text_to_cypher_with_context(
         }
     };
 
-    TextToCypherResponse::success_with_usage(schema, cypher_query, Some(cypher_result), answer, Some(token_usage))
+    let mut response =
+        TextToCypherResponse::success_with_usage(schema, cypher_query, Some(cypher_result), answer, Some(token_usage));
+    response.confidence = confidence;
+    response
 }
 
 /// Resolve the UDF context block for a request based on its [`UdfSource`].

--- a/templates/last_request_prompt.txt
+++ b/templates/last_request_prompt.txt
@@ -3,3 +3,5 @@ You are answering a user's question. The data needed to answer it was already re
 Using that data, write a clear, natural-language answer to: {{USER_QUESTION}}
 
 Answer in plain prose only. Even if the question is phrased as a request to "return", "generate", "write", or "show" a query, do NOT output any cypher, query, or code — respond with the actual answer derived from the data. Do not mention the given data, the cypher query, or the cypher result.
+
+After the answer, on its own final line, output your confidence that the answer is correct given the data, in exactly this format: CONFIDENCE: <0-100> (an integer, where 100 means certain and 0 means no confidence). If the data is empty or does not support an answer, use a low value. Output nothing after that line.


### PR DESCRIPTION
## What
Adds a per-answer **confidence score** (0-100) reflecting how confident the model is that its answer is correct given the query results. Surfaced across all three consumers of the pipeline.

## How
- **Prompt**: the final-answer prompt now appends a trailing `CONFIDENCE: <0-100>` line.
- **Core**: `parse_answer_confidence()` extracts and strips that marker; `generate_final_answer_with_confidence()` returns the answer + score. The clean answer is always what callers receive.
- **REST server**: new `Progress::Confidence(u8)` SSE event. Streaming uses a tail-hold buffer so the marker never leaks into the live prose.
- **Library**: `TextToCypherResponse` gains a `confidence: Option<u8>` field (normal + self-healing paths).
- **MCP**: parses the `Confidence` event and appends `Confidence: NN%` to the tool response.

## Testing
- **REST**: live server on `path_algo` — 100 for a clean answer, 0-10 when the result can't support one.
- **Library**: live run — "list cities" → `Some(100)`; "population of Z" → `Some(10)`.
- **MCP**: unit tests assert `Confidence: NN%` is surfaced, omitted when absent, and clamped when >100.
- `cargo fmt --check`, `clippy --all-targets -D warnings` (pedantic+nursery), and full test suite (4 new tests) all pass.

## Commits
Split into 5 scoped commits: prompt → core → server → library → MCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying answer confidence alongside generated responses.
  * Confidence values can now be included in streamed chat and MCP responses when available.

* **Bug Fixes**
  * Improved streaming so confidence markers are handled safely and won’t appear split across chunks.
  * Confidence values are now normalized to stay within the 0–100 range.

* **Tests**
  * Added coverage for confidence extraction, missing confidence, and out-of-range values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->