### PR TITLE
Collect example values for relationship attributes in schema discovery

### DIFF
--- a/src/schema/discovery.rs
+++ b/src/schema/discovery.rs
@@ -79,7 +79,7 @@ impl Schema {
         let mut attributes = Self::collect_attributes(graph, label, &query).await?;
 
         // Collect example values for each attribute
-        Self::collect_example_values(graph, label, &mut attributes, sample_size).await?;
+        Self::collect_example_values(graph, label, &mut attributes, sample_size, false).await?;
 
         Ok(attributes)
     }
@@ -104,7 +104,13 @@ impl Schema {
             "
         );
 
-        Self::collect_attributes(graph, label, &query).await
+        let mut attributes = Self::collect_attributes(graph, label, &query).await?;
+
+        // Collect example values (e.g. rel_type = "MARRIED_TO") so the model can filter on
+        // structured relationship properties instead of fuzzy-matching free-text fields.
+        Self::collect_example_values(graph, label, &mut attributes, sample_size, true).await?;
+
+        Ok(attributes)
     }
 
     async fn collect_attributes(
@@ -149,6 +155,7 @@ impl Schema {
         label: &str,
         attributes: &mut [Attribute],
         sample_size: usize,
+        is_relationship: bool,
     ) -> Result<(), FalkorDBError> {
         // Validate label to prevent injection attacks
         // Labels should start with letter/underscore and contain alphanumeric/underscore
@@ -176,8 +183,13 @@ impl Schema {
             // Even with validation, this provides defense-in-depth
             let escaped_name = Self::escape_property_name(&attribute.name);
             let escaped_label = Self::escape_property_name(label);
+            let match_clause = if is_relationship {
+                format!("MATCH ()-[n:{escaped_label}]->()")
+            } else {
+                format!("MATCH (n:{escaped_label})")
+            };
             let query = format!(
-                r"MATCH (n:{escaped_label})
+                r"{match_clause}
                 WHERE n.{escaped_name} IS NOT NULL
                 RETURN DISTINCT toString(n.{escaped_name}) AS value
                 LIMIT {max_examples}"


### PR DESCRIPTION
## Problem

Schema discovery gathered example values **only for entity (node) attributes**. Relationship attributes were discovered with their property *names* but **no sample values**.

As a result, the model saw that a `RELATES` edge has a `rel_type` property, but never saw that its values are things like `MARRIED_TO`, `PARENT_OF`, `ALIAS`. Blind to those values, it fell back to fragile free-text matching — e.g. asking "who is X's wife?" produced `WHERE r.fact CONTAINS 'wife'`, which matched nothing because the stored text says *"married to"*. The answer came back empty even though the data was present.

## Fix

Generalize `collect_example_values` with an `is_relationship` flag that swaps the node pattern `MATCH (n:Label)` for the edge pattern `MATCH ()-[n:Label]->()`, and call it from `collect_relationship_attributes` so edges surface example values just like nodes.

## Verification (live, on a GraphRAG-style graph)

Discovered schema now includes relationship example values:
```
RELATES | rel_type => ["EVENT_OCCURRED_ON", "DEPARTED_FROM", "LOCATED_NEAR", ...]
```

End-to-end, "Who is Samuel Whitford's wife?":
- **Before:** `... WHERE r.fact CONTAINS 'wife' ...` → no result → "couldn't find the wife"
- **After:** `MATCH (p:Person {name:'Samuel Whitford'})-[:RELATES]->(w:Person) RETURN w.name` → **"Eleanor Whitford"**

## Checks
- `cargo build --release` ✅
- `cargo clippy --lib -- -W clippy::pedantic -W clippy::nursery -D warnings` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema discovery so example values are collected correctly for both node properties and relationship properties.
  * Relationship property details now show more accurate example data during discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->