### PR TITLE
Bump version to v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"


### PR DESCRIPTION
Bumps the crate version from 0.2.2 to 0.2.3 in Cargo.toml and Cargo.lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version from 0.2.2 to 0.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->