### PR TITLE
Bump version to v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"


### PR DESCRIPTION
Bumps the crate version from 0.2.3 to 0.2.4 so the publish workflow can release the confidence-scoring fix from #169 (0.2.3 is already on crates.io).