### PR TITLE
Bump version to v0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"


### PR DESCRIPTION
Bump version to v0.2.5 so the next Docker release picks up FalkorDB v4.20.1 as its base image.

Why: the current v0.2.4 image bundles FalkorDB 4.18.11, where weighted `algo.SPpaths` without `maxLen` never returns and pins the CPU at 100% (this is what froze the Snowflake app). Verified locally on the air routes dataset (47,885 airports / 65,888 routes):

- FalkorDB 4.18.11: unbounded weighted SPpaths never returns, CPU 100%, TIMEOUT ignored
- FalkorDB v4.20.1: same query answers in ~3.5ms via Dijkstra, browser UI verified reachable (HTTP 200)