### PR TITLE
chore: require falkordb-rs 0.10.3 and bump to 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"
@@ -49,7 +49,7 @@ serde_yaml_ng = "0.10"
 tracing = { version = "0.1", features = ["default"] }
 tokio = { version = "1.52.3", features = ["full"] }
 genai = "0.6.5"
-falkordb = { version = "0.10.0", features = ["tokio"] }
+falkordb = { version = "0.10.3", features = ["tokio"] }
 # `falkordb` returns `redis::Value` from `udf_list`; depend on the same redis (cargo unifies to one
 # copy) so we can parse the `GRAPH.UDF LIST` reply in `src/udf.rs`.
 redis = { version = "1", default-features = false }


### PR DESCRIPTION
Pins `falkordb` to 0.10.3, which unsets the redis-rs 1.x default 500ms response timeout (falkordb-rs#297). Queries over 500ms (LOAD CSV, heavy traversals) no longer fail client-side while the server keeps executing, which also caused duplicate writes on retry.

No code changes needed: 0.10.3 defaults to no client-side response timeout, so the server's TIMEOUT/TIMEOUT_DEFAULT config governs query duration.

- `falkordb` 0.10.0 → 0.10.3 (explicit pin; lockfile already resolved 0.10.3 via #177)
- text-to-cypher 0.2.5 → 0.2.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.2.6.
  * Updated the FalkorDB integration to version 0.10.3 while retaining Tokio support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->