### PR TITLE
fix: normalize FalkorDB parameter headers in generated Cypher

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -272,7 +272,7 @@ fn param_header_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r#"(?is)^\s*(?:cypher\s+)?((?:[a-z_][a-z0-9_]*\s*=\s*(?:'[^']*'|"[^"]*"|\[[^\]]*\]|[^\s,]+)\s*,?\s*)+)(match|optional|call|return|with|unwind|create|merge)\b"#,
+            r#"(?is)^\s*(?:cypher\s+)?((?:[a-z_][a-z0-9_]*\s*=\s*(?:'[^']*'|"[^"]*"|\[[^\]]*\]|\{[^}]*\}|\([^)]*\)|[^\s,]+)\s*,?\s*)+)(match|optional|call|return|with|unwind|create|merge)\b"#,
         )
         .expect("valid param header regex")
     })
@@ -924,6 +924,22 @@ mod tests {
         assert_eq!(
             clean_generated_cypher_response("CYPHER a='x', b=2, ids=[1,2,3] MATCH (n) RETURN n"),
             "CYPHER a='x' b=2 ids=[1,2,3] MATCH (n) RETURN n"
+        );
+    }
+
+    #[test]
+    fn clean_generated_cypher_response_preserves_commas_in_quoted_param_values() {
+        assert_eq!(
+            clean_generated_cypher_response("name='Doe, John', city=\"a, b\" MATCH (n {name: $name}) RETURN n"),
+            "CYPHER name='Doe, John' city=\"a, b\" MATCH (n {name: $name}) RETURN n"
+        );
+    }
+
+    #[test]
+    fn clean_generated_cypher_response_preserves_commas_in_map_param_values() {
+        assert_eq!(
+            clean_generated_cypher_response("opts={x:1,y:2}, ids=[1,2] MATCH (n) RETURN n"),
+            "CYPHER opts={x:1,y:2} ids=[1,2] MATCH (n) RETURN n"
         );
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -17,6 +17,7 @@ use genai::chat::ChatMessage as GenAiChatMessage;
 use genai::resolver::{AuthData, AuthResolver, Endpoint, ServiceTargetResolver};
 use genai::{Client as GenAiClient, ModelIden};
 use regex::Regex;
+use std::borrow::Cow;
 use std::error::Error;
 use std::sync::OnceLock;
 
@@ -254,11 +255,69 @@ pub fn clean_generated_cypher_response(response: &str) -> String {
 
     query = strip_known_prefixes(query);
     query = strip_surrounding_quotes(query);
+
+    let normalized = normalize_parameter_header(query);
+    let mut query = normalized.as_ref();
+
     query = trim_to_first_cypher_keyword(query);
     query = strip_explanation_suffix(query);
     query = strip_surrounding_quotes(query);
 
     query.replace('\n', " ").replace("```", "").trim().to_string()
+}
+
+/// Matches a leading `FalkorDB` parameter header: an optional `CYPHER` keyword followed by
+/// one or more `name=value` pairs (possibly comma-separated) before the first query clause.
+fn param_header_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?is)^\s*(?:cypher\s+)?((?:[a-z_][a-z0-9_]*\s*=\s*(?:'[^']*'|"[^"]*"|\[[^\]]*\]|[^\s,]+)\s*,?\s*)+)(match|optional|call|return|with|unwind)\b"#,
+        )
+        .expect("valid param header regex")
+    })
+}
+
+/// Normalizes a `FalkorDB` parameter header so the query parses:
+/// ensures the mandatory `CYPHER` prefix and replaces comma separators
+/// between `name=value` pairs with spaces (`FalkorDB` accepts spaces only).
+fn normalize_parameter_header(query: &str) -> Cow<'_, str> {
+    let Some(caps) = param_header_regex().captures(query) else {
+        return Cow::Borrowed(query);
+    };
+
+    let pairs = caps.get(1).map_or("", |m| m.as_str());
+    let rest = caps.get(2).map_or(query, |m| &query[m.start()..]);
+    Cow::Owned(format!("CYPHER {} {rest}", strip_top_level_commas(pairs).trim()))
+}
+
+/// Replaces commas outside quoted values and brackets with spaces,
+/// collapsing runs of whitespace outside quotes.
+fn strip_top_level_commas(pairs: &str) -> String {
+    let mut quote: Option<char> = None;
+    let mut depth = 0_i32;
+    let mut out = String::with_capacity(pairs.len());
+    for mut c in pairs.chars() {
+        match quote {
+            Some(q) if c == q => quote = None,
+            Some(_) => {}
+            None => match c {
+                '\'' | '"' => quote = Some(c),
+                '[' | '{' | '(' => depth += 1,
+                ']' | '}' | ')' => depth -= 1,
+                ',' if depth == 0 => c = ' ',
+                _ => {}
+            },
+        }
+        if quote.is_none() && c.is_whitespace() {
+            if !out.ends_with(' ') {
+                out.push(' ');
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 fn extract_fenced_block(response: &str) -> Option<&str> {
@@ -305,12 +364,12 @@ fn strip_surrounding_quotes(mut query: &str) -> &str {
 
 fn trim_to_first_cypher_keyword(query: &str) -> &str {
     let trimmed = query.trim_start();
-    if starts_with_cypher_keyword(trimmed) {
+    if starts_with_cypher_keyword(trimmed) || param_header_regex().is_match(trimmed) {
         return trimmed;
     }
 
     let lower = trimmed.to_ascii_lowercase();
-    ["match", "call", "return", "with", "unwind", "create", "merge"]
+    ["match", "optional", "call", "return", "with", "unwind", "create", "merge"]
         .iter()
         .filter_map(|keyword| find_word(&lower, keyword))
         .min()
@@ -319,7 +378,7 @@ fn trim_to_first_cypher_keyword(query: &str) -> &str {
 
 fn starts_with_cypher_keyword(query: &str) -> bool {
     let lower = query.to_ascii_lowercase();
-    ["match", "call", "return", "with", "unwind", "create", "merge"]
+    ["match", "optional", "call", "return", "with", "unwind", "create", "merge"]
         .iter()
         .any(|keyword| lower.starts_with(keyword) && is_word_boundary(&lower, keyword.len()))
 }
@@ -329,7 +388,7 @@ fn find_word(
     needle: &str,
 ) -> Option<usize> {
     haystack.match_indices(needle).find_map(|(index, _)| {
-        let before_is_boundary = index == 0 || is_word_boundary(haystack, index);
+        let before_is_boundary = index == 0 || is_word_boundary(haystack, index - 1);
         let after_is_boundary = is_word_boundary(haystack, index + needle.len());
         (before_is_boundary && after_is_boundary).then_some(index)
     })
@@ -847,6 +906,48 @@ mod tests {
         assert_eq!(
             clean_generated_cypher_response("MATCH (n) RETURN count(n) Explanation: this counts all nodes"),
             "MATCH (n) RETURN count(n)"
+        );
+    }
+
+    #[test]
+    fn clean_generated_cypher_response_adds_missing_cypher_prefix_to_param_header() {
+        assert_eq!(
+            clean_generated_cypher_response(
+                "sourceCode='MAD' , targetCode='BUD' MATCH (src:airport {code: $sourceCode}) RETURN src.code"
+            ),
+            "CYPHER sourceCode='MAD' targetCode='BUD' MATCH (src:airport {code: $sourceCode}) RETURN src.code"
+        );
+    }
+
+    #[test]
+    fn clean_generated_cypher_response_removes_commas_from_param_header() {
+        assert_eq!(
+            clean_generated_cypher_response("CYPHER a='x', b=2, ids=[1,2,3] MATCH (n) RETURN n"),
+            "CYPHER a='x' b=2 ids=[1,2,3] MATCH (n) RETURN n"
+        );
+    }
+
+    #[test]
+    fn clean_generated_cypher_response_keeps_valid_param_header() {
+        assert_eq!(
+            clean_generated_cypher_response("CYPHER name='Alice' MATCH (u:User {name: $name}) RETURN u.id"),
+            "CYPHER name='Alice' MATCH (u:User {name: $name}) RETURN u.id"
+        );
+    }
+
+    #[test]
+    fn clean_generated_cypher_response_trims_leading_prose() {
+        assert_eq!(
+            clean_generated_cypher_response("Here is the query you asked for: MATCH (n) RETURN n"),
+            "MATCH (n) RETURN n"
+        );
+    }
+
+    #[test]
+    fn clean_generated_cypher_response_keeps_optional_match_start() {
+        assert_eq!(
+            clean_generated_cypher_response("OPTIONAL MATCH (n) RETURN n"),
+            "OPTIONAL MATCH (n) RETURN n"
         );
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -272,7 +272,7 @@ fn param_header_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r#"(?is)^\s*(?:cypher\s+)?((?:[a-z_][a-z0-9_]*\s*=\s*(?:'[^']*'|"[^"]*"|\[[^\]]*\]|[^\s,]+)\s*,?\s*)+)(match|optional|call|return|with|unwind)\b"#,
+            r#"(?is)^\s*(?:cypher\s+)?((?:[a-z_][a-z0-9_]*\s*=\s*(?:'[^']*'|"[^"]*"|\[[^\]]*\]|[^\s,]+)\s*,?\s*)+)(match|optional|call|return|with|unwind|create|merge)\b"#,
         )
         .expect("valid param header regex")
     })
@@ -304,7 +304,7 @@ fn strip_top_level_commas(pairs: &str) -> String {
             None => match c {
                 '\'' | '"' => quote = Some(c),
                 '[' | '{' | '(' => depth += 1,
-                ']' | '}' | ')' => depth -= 1,
+                ']' | '}' | ')' => depth = (depth - 1).max(0),
                 ',' if depth == 0 => c = ' ',
                 _ => {}
             },
@@ -941,6 +941,23 @@ mod tests {
             clean_generated_cypher_response("Here is the query you asked for: MATCH (n) RETURN n"),
             "MATCH (n) RETURN n"
         );
+    }
+
+    #[test]
+    fn clean_generated_cypher_response_normalizes_param_header_before_create() {
+        assert_eq!(
+            clean_generated_cypher_response("x=1, y='a' CREATE (n {v: $x, w: $y}) RETURN n"),
+            "CYPHER x=1 y='a' CREATE (n {v: $x, w: $y}) RETURN n"
+        );
+        assert_eq!(
+            clean_generated_cypher_response("CYPHER x=1 MERGE (n {v: $x}) RETURN n"),
+            "CYPHER x=1 MERGE (n {v: $x}) RETURN n"
+        );
+    }
+
+    #[test]
+    fn strip_top_level_commas_clamps_on_unmatched_closer() {
+        assert_eq!(strip_top_level_commas("a=) , b=1 , c=2"), "a=) b=1 c=2");
     }
 
     #[test]

--- a/templates/falkordb_reference.txt
+++ b/templates/falkordb_reference.txt
@@ -15,6 +15,9 @@ Returns the k approximate nearest neighbors ordered by similarity.
 Parameterized queries (plan caching + safety):
 Prefix with CYPHER and declare values, then reference them with $name:
 CYPHER name='Alice' MATCH (u:User {name: $name}) RETURN u.id
+The CYPHER keyword is mandatory and parameter pairs are separated by spaces, NOT commas
+(e.g. CYPHER a='x' b='y' MATCH ...). A query that starts with bare name=value pairs or
+uses commas between pairs fails to parse.
 Prefer parameters for user-supplied values.
 
 Paths and traversal:


### PR DESCRIPTION
## Problem

Reported with the airports dataset + GPT-5.2 ("please find a path from MAD to BUD"): the generated query failed FalkorDB parsing with

```
errMsg: Invalid input 'o': expected SET or START line: 1, column: 2, offset: 1
errCtx: sourceCode='MAD' , targetCode='BUD' MATCH (src:airport {code: $sourceCode}), ...
```

Root cause — the LLM emits FalkorDB's parameter-header syntax incorrectly:
1. **Missing the mandatory `CYPHER` keyword** (`sourceCode='MAD' ... MATCH`) → the exact reported error
2. **Comma-separated pairs** (`CYPHER a='x', b='y'`) → FalkorDB requires space-separated pairs

Reproduced both live against FalkorDB, including with a real `gpt-5` run through the server.

## Fix

- `clean_generated_cypher_response` now detects a leading param header and repairs it: prepends the missing `CYPHER`, replaces top-level commas with spaces (quote/bracket-aware, so `ids=[1,2,3]` is preserved)
- Fixed a latent boundary bug in `find_word` that made `trim_to_first_cypher_keyword` dead code; added `OPTIONAL` to recognized query-start keywords
- `templates/falkordb_reference.txt` now explicitly warns the LLM about both rules (prevention at generation time)

## Testing

- 6 new unit tests; full suite (193 tests) passes; clippy pedantic/nursery + fmt clean
- E2E: the exact reported query, after cleaning, executes on live FalkorDB and returns `[MAD, BUD]`
- Live LLM tests via `/text_to_cypher` (airports graph): gpt-4o-mini, gpt-4o, gpt-4.1, gpt-5-mini, gpt-5 — all succeed; gpt-5/gpt-5-mini emitted param headers that are now handled correctly (pre-fix server reproduced the failure with the same model)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AI-generated Cypher queries that include FalkorDB parameter headers.
  * Added support for `OPTIONAL MATCH` queries and more reliable cleanup of surrounding prose, formatting, and code fences.
  * Preserved commas within quoted values and list structures while normalizing parameter syntax.

* **Documentation**
  * Clarified that Cypher queries require the `CYPHER` prefix and space-separated parameter pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->