### PR TITLE
chore: bump version to 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "text-to-cypher"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-to-cypher"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 rust-version = "1.85"
 description = "A library and REST API for translating natural language text to Cypher queries using AI models"


### PR DESCRIPTION
Bumps the crate version from 0.2.6 to 0.2.7 in `Cargo.toml` and `Cargo.lock`, in preparation for releasing the Cypher parameter-header normalization fix (#192).